### PR TITLE
fix: CLI can't integrate existing Next.js apps

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -26,7 +26,7 @@ You don't need an existing Makeswift account to get started with this guide.
     npx makeswift@latest init
     ```
 
-    After you confirm you'd like to integrate your app, the CLI generates all the necessary files in the project folder.
+    After you confirm, the CLI will create a new Next.js app in a directory with the project's name.
 
     The CLI then opens a new page in your browser where you will continue integrating your app.
 


### PR DESCRIPTION
Our CLI falls flat on its face when attempting to integrate an existing Next.js app. For this reason I'm removing any reference to that in our docs, app, and am going to remove the functionality from the CLI.