### PR TITLE
fix: broken links

### DIFF
--- a/developer/app-router/installation.mdx
+++ b/developer/app-router/installation.mdx
@@ -11,7 +11,7 @@ import ClientExample from "/snippets/reference/client.mdx"
 import NextConfigExample from "/snippets/reference/next-config.mdx"
 
 The fastest way to get started with Makeswift on a new Next.js project is to follow the
-[quickstart](/quickstart) guide. If you have an existing Next.js application
+[quickstart](/developer/quickstart) guide. If you have an existing Next.js application
 or want to set things up yourself, continue with the rest of this guide.
 
 ## System requirements
@@ -59,7 +59,7 @@ MAKESWIFT_SITE_API_KEY=paste-your-api-key-here
   </Step>
   <Step title="Add Makeswift runtime and client">
   
-Create files for the Makeswift [runtime](/reference/runtime/constructor) and [client](/reference/client/constructor).
+Create files for the Makeswift [runtime](/developer/reference/runtime/constructor) and [client](/developer/reference/client/constructor).
 
 <CodeGroup>
   <RuntimeExample />
@@ -93,7 +93,7 @@ Next.js plugins are configured in the project's next.config.js file by wrapping 
   </Step>
   <Step title="Register components with Makeswift">
   
-Create a file for registered components called `makeswift/components.tsx`. In this example, only one component is registered. However, as you register more components, we recommend creating separate files for each component and rolling up the imports in the `makeswift/components.ts` file. Learn more about [registering components](/reference/runtime/register-component).
+Create a file for registered components called `makeswift/components.tsx`. In this example, only one component is registered. However, as you register more components, we recommend creating separate files for each component and rolling up the imports in the `makeswift/components.ts` file. Learn more about [registering components](/developer/reference/runtime/register-component).
 
 ```tsx makeswift/components.tsx
 import { ReactRuntime } from "@makeswift/runtime/react"

--- a/developer/app-router/localization.mdx
+++ b/developer/app-router/localization.mdx
@@ -24,23 +24,23 @@ import LocalizationExample from "/snippets/app-router/localization.mdx"
 <Step title="Add locales in the Makeswift builder">
 Open site settings and go to the "Locales" tab:
 
-![Localization first step](../images/localization-first-step.png)
+![Localization first step](/images/localization-first-step.png)
 
 To add a new locale, click the "+ Add locale" button. You can modify or delete existing locales by hovering over the locale:
 
-![Hovering over the locale](../images/localization-hover-locale.png)
+![Hovering over the locale](/images/localization-hover-locale.png)
 
 You can also modify the default locale by hovering over the default locale and clicking the edit button.
 
 Once you add all the locales you need, it might look like this:
 
-![Manage locales in settings](../images/localization-manage-locales.png)
+![Manage locales in settings](/images/localization-manage-locales.png)
 
 </Step>
 
 <Step title="Configure your Next.js app for localization">
 
-Follow the [internationalization docs](https://nextjs.org/docs/app/building-your-application/routing/internationalization) for app router and make sure that all routes except the [Makeswift API handler](/reference/makeswift-api-handler) are nested inside `/app/[lang]`.
+Follow the [internationalization docs](https://nextjs.org/docs/app/building-your-application/routing/internationalization) for app router and make sure that all routes except the [Makeswift API handler](/developer/reference/makeswift-api-handler) are nested inside `/app/[lang]`.
 
 </Step>
 
@@ -56,7 +56,7 @@ Update your catch-all route to fetch the snapshot by locale.
 
 Once you've set everything up, you should be able to switch to the locale using the locale switcher on the builder.
 
-![Manage locales in settings](../images/localization-locales-switcher.png)
+![Manage locales in settings](/images/localization-locales-switcher.png)
 
 <Note>
 
@@ -75,7 +75,7 @@ but nested on the locale's path. For example, `es` pages will be located on `exa
 
 To use domain-based localization, just add the domain to the locale on your site settings:
 
-![Adding domain-based on settings](../images/localization-domain-based-settings.png)
+![Adding domain-based on settings](/images/localization-domain-based-settings.png)
 
 Once you've done that, the Spanish localized pages will be located on `example.es/page`.
 

--- a/developer/concepts.mdx
+++ b/developer/concepts.mdx
@@ -19,61 +19,61 @@ You can read more about props in the [React documentation](https://react.dev/lea
 
 ## Controls
 
-Controls describe the way users can pass data to your components props. Each control maps a [prop](#props) on your component to user interface elements such as <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip>. Controls are defined when [registering components](/reference/runtime/register-component).
+Controls describe the way users can pass data to your components props. Each control maps a [prop](#props) on your component to user interface elements such as <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip>. Controls are defined when [registering components](/developer/reference/runtime/register-component).
 
 There are two types of controls: [basic](#basic-controls) and [composable](#composable-controls) controls.
 
 ### Basic controls
 
-Basic controls cannot contain other controls. Multiple basic controls can provide the same type of data, but with different user interfaces. For example, you can provide a `string` to your component with a [`TextInput`](/reference/controls/text-input), [`TextArea`](/reference/controls/text-area), [`Select`](/reference/controls/select), or [`Combobox`](/reference/controls/combobox) control. Here are all of the basic controls:
+Basic controls cannot contain other controls. Multiple basic controls can provide the same type of data, but with different user interfaces. For example, you can provide a `string` to your component with a [`TextInput`](/developer/reference/controls/text-input), [`TextArea`](/developer/reference/controls/text-area), [`Select`](/developer/reference/controls/select), or [`Combobox`](/developer/reference/controls/combobox) control. Here are all of the basic controls:
 
 <CardGroup cols={3}>
   <Card
     title="Checkbox"
     icon="square-check"
-    href="/reference/controls/checkbox"
+    href="/developer/reference/controls/checkbox"
   />
-  <Card title="Color" icon="palette" href="/reference/controls/color" />
+  <Card title="Color" icon="palette" href="/developer/reference/controls/color" />
   <Card
     title="Combobox"
     icon="input-pipe"
-    href="/reference/controls/combobox"
+    href="/developer/reference/controls/combobox"
   />
-  <Card title="Image" icon="image" href="/reference/controls/image" />
-  <Card title="Link" icon="link" href="/reference/controls/link" />
-  <Card title="Number" icon="input-numeric" href="/reference/controls/number" />
-  <Card title="Select" icon="list-dropdown" href="/reference/controls/select" />
+  <Card title="Image" icon="image" href="/developer/reference/controls/image" />
+  <Card title="Link" icon="link" href="/developer/reference/controls/link" />
+  <Card title="Number" icon="input-numeric" href="/developer/reference/controls/number" />
+  <Card title="Select" icon="list-dropdown" href="/developer/reference/controls/select" />
   <Card
     title="TextArea"
     icon="align-left"
-    href="/reference/controls/text-area"
+    href="/developer/reference/controls/text-area"
   />
   <Card
     title="TextInput"
     icon="input-text"
-    href="/reference/controls/text-input"
+    href="/developer/reference/controls/text-input"
   />
 </CardGroup>
 
 There are three special basic controls that are designed for specific types of props such as `className` and `children`:
 
 <CardGroup cols={3}>
-  <Card title="RichText" icon="text" href="/reference/controls/rich-text" />
-  <Card title="Slot" icon="square-dashed" href="/reference/controls/slot" />
-  <Card title="Style" icon="droplet" href="/reference/controls/style" />
+  <Card title="RichText" icon="text" href="/developer/reference/controls/rich-text" />
+  <Card title="Slot" icon="square-dashed" href="/developer/reference/controls/slot" />
+  <Card title="Style" icon="droplet" href="/developer/reference/controls/style" />
 </CardGroup>
 
-- The [`RichText`](/reference/controls/rich-text) control provides a `ReactNode` to your component and then renders an inline rich text editor <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlay</Tooltip> wherever the builder renders the `ReactNode`.
+- The [`RichText`](/developer/reference/controls/rich-text) control provides a `ReactNode` to your component and then renders an inline rich text editor <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlay</Tooltip> wherever the builder renders the `ReactNode`.
 
-- The [`Slot`](/reference/controls/slot) control provides a `ReactNode` to your component and places a drop zone <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlay</Tooltip> wherever the builder renders the prop. Users can then add components visually to that drop zone.
+- The [`Slot`](/developer/reference/controls/slot) control provides a `ReactNode` to your component and places a drop zone <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlay</Tooltip> wherever the builder renders the prop. Users can then add components visually to that drop zone.
 
-- The [`Style`](/reference/controls/style) control provides multiple <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip> that modify various CSS properties. This data is then passed to your component as a `string` value.
+- The [`Style`](/developer/reference/controls/style) control provides multiple <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip> that modify various CSS properties. This data is then passed to your component as a `string` value.
 
 ### Composable controls
 
-Composable controls provide an `array` or `object` to a prop of your component. Composable controls have a `type` property that can recursively contain any control. The [`List`](/reference/controls/list) control is used to modify props that expect an `array`, and the [`Shape`](/reference/controls/shape) control is used to modify props that expect an `object`.
+Composable controls provide an `array` or `object` to a prop of your component. Composable controls have a `type` property that can recursively contain any control. The [`List`](/developer/reference/controls/list) control is used to modify props that expect an `array`, and the [`Shape`](/developer/reference/controls/shape) control is used to modify props that expect an `object`.
 
 <CardGroup cols={2}>
-  <Card title="List" icon="list" href="/reference/controls/list" />
-  <Card title="Shape" icon="brackets-curly" href="/reference/controls/shape" />
+  <Card title="List" icon="list" href="/developer/reference/controls/list" />
+  <Card title="Shape" icon="brackets-curly" href="/developer/reference/controls/shape" />
 </CardGroup>

--- a/developer/guides/environments.mdx
+++ b/developer/guides/environments.mdx
@@ -38,7 +38,7 @@ We recommend familiarizing yourself with Makeswift's layout controls by creating
   Examples of primitive components include Buttons, Cards, Carousels, Feeds etc.
 </Info>
 
-Once you've identified and implemented your primitive components, the next step is to [register](/reference/runtime/register-component) and test them in your local development site. The focus should be on testing the interface you are creating for your marketing team. Pages used here to test your components should be considered throwaway and not used for content publishing.
+Once you've identified and implemented your primitive components, the next step is to [register](/developer/reference/runtime/register-component) and test them in your local development site. The focus should be on testing the interface you are creating for your marketing team. Pages used here to test your components should be considered throwaway and not used for content publishing.
 
 ### Content publishing
 

--- a/developer/pages-router/installation.mdx
+++ b/developer/pages-router/installation.mdx
@@ -12,7 +12,7 @@ import ApiHandlerExample from "/snippets/pages-router/api-handler.mdx"
 import PagesAppExample from "/snippets/pages-router/pages-app.mdx"
 
 The fastest way to get started with Makeswift on a new Next.js project is to follow the
-[quickstart](/quickstart) guide. If you have an existing Next.js application
+[quickstart](/developer/quickstart) guide. If you have an existing Next.js application
 or want to set things up yourself, continue with the rest of this guide.
 
 ## System requirements
@@ -55,7 +55,7 @@ MAKESWIFT_SITE_API_KEY=paste-your-api-key-here
   </Step>
   <Step title="Add Makeswift runtime and client">
   
-Create files for the Makeswift [runtime](/reference/runtime/constructor) and [client](/reference/client/constructor).
+Create files for the Makeswift [runtime](/developer/reference/runtime/constructor) and [client](/developer/reference/client/constructor).
 
 <CodeGroup>
   <RuntimeExample />
@@ -122,7 +122,7 @@ export default class MyDocument extends Document {
   </Step>
   <Step title="Register components with Makeswift">
   
-Create a file for registered components called `makeswift/components.tsx`. In this example, only one component is registered. However, as you register more components, we recommend creating separate files for each component and rolling up the imports in the `makeswift/components.ts` file. Learn more about [registering components](/reference/runtime/register-component).
+Create a file for registered components called `makeswift/components.tsx`. In this example, only one component is registered. However, as you register more components, we recommend creating separate files for each component and rolling up the imports in the `makeswift/components.ts` file. Learn more about [registering components](/developer/reference/runtime/register-component).
 
 <ComponentsExample />
 
@@ -137,7 +137,7 @@ If you don't have a [Custom App](https://nextjs.org/docs/pages/building-your-app
 
   <Step title="Add a route for Makeswift pages">
   
-Create an [optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) named `[[...path]].tsx`. You will use this route to fetch page snapshots from the `Makeswift` client and render them using the [`Page`](/reference/components/page) component.
+Create an [optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) named `[[...path]].tsx`. You will use this route to fetch page snapshots from the `Makeswift` client and render them using the [`Page`](/developer/reference/components/page) component.
 
 <PagesCatchAllExample />
 

--- a/developer/pages-router/localization.mdx
+++ b/developer/pages-router/localization.mdx
@@ -25,17 +25,17 @@ import NextConfigDomainLocalizedExample from "/snippets/pages-router/next-config
 <Step title="Add locales in the Makeswift builder">
 Open site settings and go to the "Locales" tab:
 
-![Localization first step](../images/localization-first-step.png)
+![Localization first step](/images/localization-first-step.png)
 
 To add a new locale, click the "+ Add locale" button. You can modify or delete existing locales by hovering over the locale:
 
-![Hovering over the locale](../images/localization-hover-locale.png)
+![Hovering over the locale](/images/localization-hover-locale.png)
 
 You can also modify the default locale by hovering over the default locale and clicking the edit button.
 
 Once you add all the locales you need, it might look like this:
 
-![Manage locales in settings](../images/localization-manage-locales.png)
+![Manage locales in settings](/images/localization-manage-locales.png)
 
 </Step>
 
@@ -66,7 +66,7 @@ This code is usually located in `[[...path]].tsx`, but it might be different dep
 
 Once you've set everything up, you should be able to switch to the locale using the locale switcher on the builder.
 
-![Manage locales in settings](../images/localization-locales-switcher.png)
+![Manage locales in settings](/images/localization-locales-switcher.png)
 
 <Note>
 
@@ -85,7 +85,7 @@ but nested on the locale's path. For example, `es` pages will be located on `exa
 
 To use domain-based localization, first, add the domain to the locale on your site settings:
 
-![Adding domain-based on settings](../images/localization-domain-based-settings.png)
+![Adding domain-based on settings](/images/localization-domain-based-settings.png)
 
 Then, add the domain to your `next.config.mjs`:
 

--- a/developer/quickstart.mdx
+++ b/developer/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Quickstart"
 description:
 ---
 
-We recommend using the automatic setup to explore Makeswift in a fresh Next.js app. If you have an existing Next.js app, you can use the [manual installation](/guides/manual-installation) guide.
+We recommend using the automatic setup to explore Makeswift in a fresh Next.js app. If you have an existing Next.js app, you can use the [manual installation](/developer/app-router/installation) guide.
 
 # Requirements
 
@@ -78,7 +78,7 @@ You don't need an existing Makeswift account to get started with this guide.
       <img src="/images/registered-components.png" alt="Screenshot of custom components in toolbar" />
     </Frame>
 
-    These components will be located in the `components` folder of your Next.js app. You can explore the files ending with `.makeswift.ts` to learn more about [registering components](/reference/runtime/register-component).
+    These components will be located in the `components` folder of your Next.js app. You can explore the files ending with `.makeswift.ts` to learn more about [registering components](/developer/reference/runtime/register-component).
 
     To learn how to use Makeswift builder, see the [Help Center](https://help.makeswift.com/) articles.
 

--- a/developer/reference/client/constructor.mdx
+++ b/developer/reference/client/constructor.mdx
@@ -11,10 +11,10 @@ import ClientExample from "/snippets/reference/client.mdx"
      The API key for the Makeswift site.
    </ParamField>
 2. <ParamField query="options" type="object">
-     Options for a [runtime instance](reference/runtime/constructor).
+     Options for a [runtime instance](/developer/reference/runtime/constructor).
      <Expandable>
        <ParamField query="runtime" type="ReactRuntime">
-         A [runtime instance](/reference/runtime/constructor). Required for
+         A [runtime instance](/developer/reference/runtime/constructor). Required for
          custom breakpoints.
        </ParamField>
      </Expandable>

--- a/developer/reference/client/get-page-snapshot.mdx
+++ b/developer/reference/client/get-page-snapshot.mdx
@@ -16,7 +16,7 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
      <Expandable>
        <ParamField query="siteVersion" type="SiteVersion" required>
          The return value from
-         [`getSiteVersion`](/reference/makeswift/get-site-version).
+         [`getSiteVersion`](/developer/reference/client/get-site-version).
        </ParamField>
        <ParamField query="locale" type="string">
          A valid locale string.
@@ -28,14 +28,14 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 <ResponseField name="snapshot" type="Snapshot">
   An opaque `Snapshot` object that is only intended to be rendered by the
-  [`<Page>`](/reference/components/page) component.
+  [`<Page>`](/developer/reference/components/page) component.
 </ResponseField>
 
 ## Examples
 
 ### Basic usage
 
-The following example sets up a [catch all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) where page [snapshots](/architecture/concepts#snapshots) are fetched from Makeswift and rendered using the [`<Page>`](/reference/components/page) component.
+The following example sets up a [catch all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) where page snapshots are fetched from Makeswift and rendered using the [`<Page>`](/developer/reference/components/page) component.
 
 <PagesCatchAllExample />
 

--- a/developer/reference/client/get-pages.mdx
+++ b/developer/reference/client/get-pages.mdx
@@ -152,7 +152,7 @@ export async function getAllPages() {
 By default, `getPages` will return data reflecting the state of published
 Makeswift pages. To specify which variant of your pages you want to retrieve,
 you can pass a value to the `siteVersion` option. If your site is using pages
-router, use the [`getSiteVersion` method](/reference/client/get-site-version) to
+router, use the [`getSiteVersion` method](/developer/reference/client/get-site-version) to
 retrieve the current site version. If your site is using app router, use the
 `getSiteVersion` function.
 
@@ -330,7 +330,7 @@ A few things to note:
 ### Localization
 
 To retrieve pages that you've created in one of your [registered
-locales](/app-router/localization), you can pass the `locale` option to the
+locales](/developer/app-router/localization), you can pass the `locale` option to the
 `getPages` method. Each returned page will include any of its localized
 alternates in the `localizedVariants` field.
 
@@ -348,7 +348,7 @@ be returned. Each page will include any of its localized alternates in the
 
 For an example of how to use `getPages` with localization to statically generate
 paths in Next.js app router, [see
-here](/app-router/localization#getting-started).
+here](/developer/app-router/localization#getting-started).
 
 ## Changelog
 

--- a/developer/reference/client/get-site-version.mdx
+++ b/developer/reference/client/get-site-version.mdx
@@ -14,6 +14,6 @@ import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx"
 
 ## Example
 
-The following example sets up a [catch all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) where page snapshots are fetched from Makeswift using `siteVersion` and rendered using the [`<Page>`](/reference/components/page) component.
+The following example sets up a [catch all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) where page snapshots are fetched from Makeswift using `siteVersion` and rendered using the [`<Page>`](/developer/reference/components/page) component.
 
 <PagesCatchAllExample />

--- a/developer/reference/client/get-sitemap.mdx
+++ b/developer/reference/client/get-sitemap.mdx
@@ -6,7 +6,7 @@ description: "An instance method that provides SEO information about the pages c
 <Warning> 
   This method has been **deprecated** and will be removed in a future 
   runtime release. Use the `getPages` method to create a sitemap instead,
-  [see the documentation here](/reference/client/get-pages#generating-a-sitemap).
+  [see the documentation here](/developer/reference/client/get-pages#generating-a-sitemap).
 </Warning>
 
 <Note>

--- a/developer/reference/components/react-runtime-provider.mdx
+++ b/developer/reference/components/react-runtime-provider.mdx
@@ -1,6 +1,6 @@
 ---
 title: "<ReactRuntimeProvider>"
-description: The `<ReactRuntimeProvider>` component takes a Makeswift runtime and provides it to the [`<Page>`](/reference/components/page) component for rendering snapshots.
+description: The `<ReactRuntimeProvider>` component takes a Makeswift runtime and provides it to the [`<Page>`](/developer/reference/components/page) component for rendering snapshots.
 ---
 
 import AppProviders from "/snippets/app-router/providers.mdx";
@@ -10,7 +10,7 @@ import PagesApp from "/snippets/pages-router/pages-app.mdx";
 ## Props
 
 <ParamField query="runtime" type="Runtime" required>
-  A Makeswift [runtime](/reference/runtime/constructor).
+  A Makeswift [runtime](/developer/reference/runtime/constructor).
 </ParamField>
 
 <ParamField query="children" type="React.Node">

--- a/developer/reference/controls/list.mdx
+++ b/developer/reference/controls/list.mdx
@@ -83,7 +83,7 @@ export function Accordions({ accordionTitles }) {
 
 ### An array of objects
 
-This example uses the [Shape](/reference/controls/shape) control to define the structure of the objects in the `accordions` array.
+This example uses the [Shape](/developer/reference/controls/shape) control to define the structure of the objects in the `accordions` array.
 
 <CodeGroup>
 

--- a/developer/reference/controls/shape.mdx
+++ b/developer/reference/controls/shape.mdx
@@ -24,7 +24,7 @@ The Shape control passes an `object` based on the controls used in the `type` fi
 
 ## Example
 
-This example adds a Shape control to the `type` field of a [List](/reference/controls/list) control for a Feature Grid component.
+This example adds a Shape control to the `type` field of a [List](/developer/reference/controls/list) control for a Feature Grid component.
 
 <CodeGroup>
 

--- a/developer/reference/runtime/register-component.mdx
+++ b/developer/reference/runtime/register-component.mdx
@@ -25,7 +25,7 @@ description: Adds your components to the Makeswift builder.
           The icon shown in the Makeswift builder.
        </ParamField>
        <ParamField query="props" type="Record<string, Control>" required>
-          An object mapping prop names to Makeswift [controls](/concepts#controls).
+          An object mapping prop names to Makeswift [controls](/developer/concepts#controls).
        </ParamField>
      </Expandable>
    </ParamField>
@@ -37,7 +37,7 @@ description: Adds your components to the Makeswift builder.
 This example shows how to register a `Box` component. `'box'` is the value for `type`, which must
 be unique, as Makeswift uses this value to identify the component. This value shouldn't change once you use the
 component in the Makeswift builder. `'Box'` is the `label`, which appears in
-the Makeswift builder. The example applies a [`Style`](/controls/style) control to the
+the Makeswift builder. The example applies a [`Style`](/developer/reference/controls/style) control to the
 `className` prop.
 
 ```tsx makeswift/components.tsx
@@ -187,4 +187,4 @@ import "@/components/Sphere/Sphere.makeswift"
  */
 ```
 
-The file `makeswift/components.ts` should be imported wherever you use [`<ReactRuntimeProvider>`](/reference/components/react-runtime-provider) in your app.
+The file `makeswift/components.ts` should be imported wherever you use [`<ReactRuntimeProvider>`](/developer/reference/components/react-runtime-provider) in your app.

--- a/developer/upgrading/0.13.0.mdx
+++ b/developer/upgrading/0.13.0.mdx
@@ -2,7 +2,7 @@
 title: Upgrading to 0.13.0
 ---
 
-If you haven't upgraded to `0.9.0` please read the [upgrading guide](/upgradings/0.9.0).
+If you haven't upgraded to `0.9.0` please read the [upgrading guide](/developer/upgrading/0.9.0).
 
 ### Update getPageSnapshot Parameters
 

--- a/developer/upgrading/0.14.0.mdx
+++ b/developer/upgrading/0.14.0.mdx
@@ -2,7 +2,7 @@
 title: Upgrading to 0.14.0
 ---
 
-If you haven't upgraded to `0.13.0` please read the [upgrading guide](/upgrading/0.13.0).
+If you haven't upgraded to `0.13.0` please read the [upgrading guide](/developer/upgrading/0.13.0).
 
 ### Update the API handler file
 
@@ -23,6 +23,6 @@ These exported functions from `@makeswift/runtime/next` were deprecated:
 - `getStaticProps`
 - `getServerSideProps`
 
-To replace these functions, please follow the [manual installation](/guides/manual-installation) guide.
+To replace these functions, please follow the [manual installation](/developer/pages-router/installation) guide.
 
 Here is the link to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.14.0).

--- a/developer/upgrading/0.15.0.mdx
+++ b/developer/upgrading/0.15.0.mdx
@@ -2,7 +2,7 @@
 title: Upgrading to 0.15.0
 ---
 
-If you haven't upgraded to `0.14.0` please read the [upgrading guide](/upgrading/0.14.0).
+If you haven't upgraded to `0.14.0` please read the [upgrading guide](/developer/upgrading/0.14.0).
 
 ### Add `ReactRuntimeProvider` to your Next.js Custom App
 

--- a/developer/upgrading/0.18.0.mdx
+++ b/developer/upgrading/0.18.0.mdx
@@ -2,7 +2,7 @@
 title: Upgrading to 0.18.0
 ---
 
-If you haven't upgraded to `0.15.0` please read the [upgrading guide](/upgrading/0.15.0).
+If you haven't upgraded to `0.15.0` please read the [upgrading guide](/developer/upgrading/0.15.0).
 
 ## Migrate to @makeswift/runtime/controls
 
@@ -21,7 +21,7 @@ For most controls, you can simply update the import statement. Here's an example
 + import { RichText } from '@makeswift/runtime/controls';
 ```
 
-For detailed information on how to use each control, refer to the respective control's documentation. For example, here's the docs for the [RichText control]((/reference/controls/rich-text)).
+For detailed information on how to use each control, refer to the respective control's documentation. For example, here's the docs for the [RichText control](/developer/reference/controls/rich-text).
 
 ### Special Cases
 
@@ -31,4 +31,4 @@ Refer to the documentation for each control to see if any special migration step
 
 ### Learn More
 
-For more information about the available controls and how to use them, please refer to the [controls documentation](/concepts#basic-controls).
+For more information about the available controls and how to use them, please refer to the [controls documentation](/developer/concepts#controls).

--- a/developer/upgrading/0.19.0.mdx
+++ b/developer/upgrading/0.19.0.mdx
@@ -2,7 +2,7 @@
 title: Upgrading to 0.19.0
 ---
 
-If you haven't upgraded to `0.18.0` please read the [upgrading guide](/upgrading/0.18.0).
+If you haven't upgraded to `0.18.0` please read the [upgrading guide](/developer/upgrading/0.18.0).
 
 <Warning>
   This upgrade guide is only necessary if you're using the `getPages` Makeswift
@@ -38,7 +38,7 @@ async iterable which includes methods `.map` and `.filter`, in addition to
 include several more data fields from the Makeswift page.
 
 For more information about the usage of the `getPages` client method, please
-refer to the [`getPages` documentation](/reference/client/get-pages).
+refer to the [`getPages` documentation](/developer/reference/client/get-pages).
 
 ### Deprecation of `getSitemap`
 

--- a/product/component/property-controls/backgrounds.mdx
+++ b/product/component/property-controls/backgrounds.mdx
@@ -11,11 +11,11 @@ Multiple backgrounds can be layered and sorted within a single box, including th
 - Gradients
 - Videos
 
-<Frame>![Background propery](//images/builder/backgrounds1.gif)</Frame>
+<Frame>![Background propery](/images/builder/backgrounds1.gif)</Frame>
 
 ## Colors
 
-Colors can be set as a background fill. You can also layer translucent colors on top of background images to add overlays.
+Colors can be set as a background fill. You can also layer translucent colors on top of backgroundimages to add overlays.
 
 <Frame>![Background colors](/images/builder/backgrounds2.gif)</Frame>
 

--- a/product/page/metadata.mdx
+++ b/product/page/metadata.mdx
@@ -22,7 +22,7 @@ Makeswift also uses these meta tags as the Open Graph (OG) and X (Twitter) equiv
 </Note>
 
 <Frame>
-  <img width="300" src="/images/seo-Metadata/metatags.png" />
+  <img width="300" src="/images/seo-metadata/metatags.png" />
 </Frame>
 
 ## Canonical URL

--- a/product/quickstart.mdx
+++ b/product/quickstart.mdx
@@ -41,7 +41,7 @@ icon: "bolt" iconType: "solid"
   >
     Design your website to be responsive across all devices
   </Card>
-  <Card title="SEO" icon="magnifying-glass-chart" href="/product/seo">
+  <Card title="SEO" icon="magnifying-glass-chart" href="/product/SEO">
     Optimize SEO for your site more easily than ever
   </Card>
   <Card

--- a/snippets/naming-conventions.mdx
+++ b/snippets/naming-conventions.mdx
@@ -1,5 +1,5 @@
 <Info>
   `.makeswift.ts` is a naming convention for organizing Makeswift registration
   code. [Learn
-  more](/reference/runtime/register-component#organizing-registration-code).
+  more](/developer/reference/runtime/register-component#organizing-registration-code).
 </Info>


### PR DESCRIPTION
You can easily search for broken links by running the command:

mintlify broken-links

There are still 5 broken links because the CLI has a bug for a link that has dot ".":

https://github.com/mintlify/docs/issues/178#issuecomment-2191014928