### PR TITLE
Added prettierrc for consistent styling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
Adding the prettier configuration file will prevent local prettier configurations from overriding team decisions. This file includes settings that match the existing format of docs.