### PR TITLE
Added redirect for rich-text control docs

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -335,6 +335,10 @@
       "destination": "/developer/reference/controls/text-input"
     },
     {
+      "source": "/docs/controls/rich-text",
+      "destination": "/developer/reference/controls/rich-text"
+    },
+    {
       "source": "/reference/makeswift-api-handler",
       "destination": "/developer/reference/makeswift-api-handler"
     },

--- a/mint.json
+++ b/mint.json
@@ -335,7 +335,7 @@
       "destination": "/developer/reference/controls/text-input"
     },
     {
-      "source": "/docs/controls/rich-text",
+      "source": "/controls/rich-text",
       "destination": "/developer/reference/controls/rich-text"
     },
     {


### PR DESCRIPTION
Added redirect from outdated url for rich-text docs `https://www.makeswift.com/docs/controls/rich-text` (referenced in screenshot)

![CleanShot 2024-08-13 at 14 01 07](https://github.com/user-attachments/assets/388c562f-281e-457b-8b6a-c3468e07f3bb)
