### PR TITLE
Developer Quickstart - h1 to h2

### DIFF
--- a/developer/quickstart.mdx
+++ b/developer/quickstart.mdx
@@ -5,7 +5,7 @@ description:
 
 We recommend using the automatic setup to explore Makeswift in a fresh Next.js app. If you have an existing Next.js app, you can use the [manual installation](/developer/app-router/installation) guide.
 
-# Requirements
+## Requirements
 
 You will need the following:
 
@@ -15,7 +15,7 @@ You will need the following:
 
 You don't need an existing Makeswift account to get started with this guide.
 
-# Automatic setup
+## Automatic setup
 
 <Steps>
   <Step title="Initialize the app">


### PR DESCRIPTION
Developer quickstart was using h1 headings that have been changed to h2