### PR TITLE
Update: callout for optional catch-all route

### DIFF
--- a/developer/app-router/installation.mdx
+++ b/developer/app-router/installation.mdx
@@ -137,12 +137,12 @@ This catch-all route will fetch page data from `Makeswift` and pass it to be ren
 
 Delete the root page component `src/app/page.tsx` file to ensure that all pages (including the home page) are managed by Makeswift.
 
-<Info>
+<Note>
   Optional catch-all routes match the parent route which, in this case, would be
   the root page `/`. If you wanted to have a hard-coded home page (not managed
   by Makeswift), you could use a (non-optional) catch-all route which does not
   match the parent route and uses single brackets instead (ex. `[...path]`).
-</Info>
+</Note>
 
   </Step>
   

--- a/developer/app-router/installation.mdx
+++ b/developer/app-router/installation.mdx
@@ -135,11 +135,14 @@ This catch-all route will fetch page data from `Makeswift` and pass it to be ren
 
 <CatchAllExample />
 
-<Note>
-  Make sure to remove the root page component at `src/app/page.tsx` file. This
-  will ensure all pages are managed by Makeswift. Otherwise, you'll get a
-  specificity error on your routes.
-</Note>
+Delete the root page component `src/app/page.tsx` file to ensure that all pages (including the home page) are managed by Makeswift.
+
+<Info>
+  Optional catch-all routes match the parent route which, in this case, would be
+  the root page `/`. If you wanted to have a hard-coded home page (not managed
+  by Makeswift), you could use a (non-optional) catch-all route which does not
+  match the parent route and uses single brackets instead (ex. `[...path]`).
+</Info>
 
   </Step>
   


### PR DESCRIPTION
Move instructions to delete the root page component outside of a callout. Added a callout to clarify the use case of non-optional route and how to support a hard-coded home page.