### PR TITLE
[WIP] DOCS: Release <MakeswiftComponent>

### DIFF
--- a/developer/app-router/installation.mdx
+++ b/developer/app-router/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: App router
 ---
 
 import CatchAllExample from "/snippets/app-router/catch-all.mdx";

--- a/developer/app-router/localization.mdx
+++ b/developer/app-router/localization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Localization
+title: App router
 description: "This guide walks you through setting up localization for your Makeswift site so you can visually customize your site for different locales."
 ---
 

--- a/developer/caching/overview.mdx
+++ b/developer/caching/overview.mdx
@@ -1,0 +1,5 @@
+---
+title: Overview
+description: "Learn the basics of building with Makeswift, including components, theming, responsive design, and publishing."
+icon: "globe"
+---

--- a/developer/caching/tag-based-revalidation.mdx
+++ b/developer/caching/tag-based-revalidation.mdx
@@ -1,0 +1,5 @@
+---
+title: Tag-based Revalidation
+icon: "tag"
+description: "Learn how to use tag-based revalidation to improve performance and reduce load times."
+---

--- a/developer/caching/time-based-revalidation.mdx
+++ b/developer/caching/time-based-revalidation.mdx
@@ -1,0 +1,15 @@
+---
+title: Time-based Revalidation
+description: "Learn how to use time-based revalidation to update static content without rebuilding your entire site."
+icon: "clock"
+---
+
+import InstallationRequirement from "/snippets/callouts/installation-requirement.mdx";
+
+By using [Incremental Static Regeneration (ISR)](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration), you can update static content in your Next.js applications on a time-based interval that you define in your code without having to rebuilt your entire site.
+
+<InstallationRequirement />
+
+## Enabling time-based revalidation
+
+To enable ISR, export a `revalidate` property in a page component (a `page.tsx` file).

--- a/developer/pages-router/installation.mdx
+++ b/developer/pages-router/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Pages router
 ---
 
 import RuntimeExample from "/snippets/reference/runtime.mdx";

--- a/developer/pages-router/localization.mdx
+++ b/developer/pages-router/localization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Localization
+title: Pages router
 description: "This guide walks you through setting up localization for your Makeswift site so you can visually customize your site for different locales."
 ---
 

--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -1,6 +1,6 @@
 ---
-title: "getPageSnapshot (deprecated)"
-description: "An instance method that fetches a snapshot of a Makeswift page at a given path. This snapshot is only intended to be rendered by the `<Page>` component."
+title: "getComponentSnapshot"
+description: "An instance method that fetches a snapshot of a Makeswift component with a specific id. This snapshot is only intended to be rendered by the [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) component."
 ---
 
 import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx";
@@ -8,8 +8,8 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 ## Arguments
 
-1. <ParamField query="pathname" type="string" required>
-     The path of the page.
+1. <ParamField query="id" type="string" required>
+     The id of the component.
    </ParamField>
 2. <ParamField query="options" type="object" required>
      Options for site version and locale.
@@ -28,7 +28,7 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 <ResponseField name="snapshot" type="Snapshot">
   An opaque `Snapshot` object that is only intended to be rendered by the
-  [`<Page>`](/developer/reference/components/page) component.
+  [`<MakeswiftComponent>`](/developer/reference/components/MakeswiftComponent) component.
 </ResponseField>
 
 ## Examples

--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -26,6 +26,11 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
        <ParamField query="locale" type="string">
          A valid locale string.
        </ParamField>
+       <ParamField query="next" type="object">
+         A [Next.js fetch()
+         options](https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options)
+         object
+       </ParamField>
      </Expandable>
    </ParamField>
 

--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -1,6 +1,6 @@
 ---
 title: "getComponentSnapshot"
-description: "An instance method that fetches a snapshot of a Makeswift component with a specific id. This snapshot is only intended to be rendered by the [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) component."
+description: "An instance method of the Makeswift [client](/developer/reference/client/constructor) that fetches a snapshot of a Makeswift component by its `id`. This snapshot is only intended to be rendered by [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component)."
 ---
 
 import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx";
@@ -28,19 +28,36 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 <ResponseField name="snapshot" type="Snapshot">
   An opaque `Snapshot` object that is only intended to be rendered by the
-  [`<MakeswiftComponent>`](/developer/reference/components/MakeswiftComponent) component.
+  [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) component.
 </ResponseField>
 
 ## Examples
 
+The following examples expect that you have a Makeswift client instance already configured and exported from `"@/makeswift/client.ts"`. If you don't, see the [client](/developer/reference/client/constructor) reference.
+
 ### Basic usage
 
-The following example sets up a [catch all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments) where page snapshots are fetched from Makeswift and rendered using the [`<Page>`](/developer/reference/components/page) component.
+```tsx
+import { client } from "@/makeswift/client";
+import { getSiteVersion } from "@makeswift/runtime/next/server";
 
-<PagesCatchAllExample />
+const productDetailSnapshot = await client.getComponentSnapshot(
+  `my-product-details`,
+  {
+    siteVersion: getSiteVersion(),
+  }
+);
+```
 
 ### Localization
 
-The following example uses the `locale` param in `getStaticProps` to fetch a localized snapshot of a page.
+```tsx
+import { client } from "@/makeswift/client";
+import { getSiteVersion } from "@makeswift/runtime/next/server";
 
-<PagesCatchAllLocalizedExample />
+const locale = "en-US";
+const snapshot = await client.getComponentSnapshot(id, {
+  siteVersion: getSiteVersion(),
+  locale,
+});
+```

--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -26,7 +26,7 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 ## Return type
 
-<ResponseField name="snapshot" type="Snapshot">
+<ResponseField name="snapshot" type="Promise<MakeswiftComponentSnapshot | null>">
   An opaque `Snapshot` object that is only intended to be rendered by the
   [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) component.
 </ResponseField>

--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -3,6 +3,11 @@ title: "getComponentSnapshot"
 description: "An instance method of the Makeswift [client](/developer/reference/client/constructor) that fetches a snapshot of a Makeswift component by its `id`. This snapshot is only intended to be rendered by [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component)."
 ---
 
+<Warning>
+  This API is a WIP and is subject to change. To use this API, you can use the
+  following version of the Makeswift runtime: `0.0.0-snapshot-20241113160601`
+</Warning>
+
 import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx";
 import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-localized.mdx";
 

--- a/developer/reference/client/get-page-snapshot.mdx
+++ b/developer/reference/client/get-page-snapshot.mdx
@@ -32,7 +32,7 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
 
 ## Return type
 
-<ResponseField name="snapshot" type="Snapshot">
+<ResponseField name="snapshot" type="Promise<MakeswiftPageSnapshot | null>">
   An opaque `Snapshot` object that is only intended to be rendered by the
   [`<Page>`](/developer/reference/components/page) component.
 </ResponseField>

--- a/developer/reference/client/get-page-snapshot.mdx
+++ b/developer/reference/client/get-page-snapshot.mdx
@@ -1,10 +1,16 @@
 ---
-title: "getPageSnapshot (deprecated)"
-description: "An instance method that fetches a snapshot of a Makeswift page at a given path. This snapshot is only intended to be rendered by the `<Page>` component."
+title: "getPageSnapshot"
+description: "An instance method of the Makeswift [client](/developer/reference/client/constructor) that fetches a snapshot of a Makeswift page at a given path. This snapshot is only intended to be rendered by the `<Page>` component."
 ---
 
 import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx";
 import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-localized.mdx";
+
+<Warning>
+  This method is deprecated. We recommend using
+  [getComponentSnapshot](/developer/reference/client/get-component-snapshot)
+  instead.
+</Warning>
 
 ## Arguments
 

--- a/developer/reference/client/get-page-snapshot.mdx
+++ b/developer/reference/client/get-page-snapshot.mdx
@@ -27,6 +27,11 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
        <ParamField query="locale" type="string">
          A valid locale string.
        </ParamField>
+       <ParamField query="next" type="object">
+         A [Next.js fetch()
+         options](https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options)
+         object
+       </ParamField>
      </Expandable>
    </ParamField>
 

--- a/developer/reference/client/get-sitemap.mdx
+++ b/developer/reference/client/get-sitemap.mdx
@@ -5,7 +5,7 @@ description: "An instance method that provides SEO information about the pages c
 
 <Warning> 
   This method has been **deprecated** and will be removed in a future 
-  runtime release. Use the `getPages` method to create a sitemap instead,
+  runtime release. Use the [`getPages`](/developer/reference/client/get-pages) method to create a sitemap instead,
   [see the documentation here](/developer/reference/client/get-pages#generating-a-sitemap).
 </Warning>
 

--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -19,8 +19,8 @@ description: The `<MakeswiftComponent>` component takes a `MakeswiftComponentSna
 3. <ParamField query="type" type="string" required>
      The type of the registered Makeswift component.
    </ParamField>
-4. <ParamField query="fallback" type="string">
-     The type of the registered Makeswift component.
+4. <ParamField query="fallback" type="ReactNode">
+     The default content to be displayed if no content has been added yet.
    </ParamField>
 
 ## Example

--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -3,54 +3,87 @@ title: "<MakeswiftComponent>"
 description: The `<MakeswiftComponent>` component takes a Makeswift snapshot and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
 ---
 
-import PagesCatchAllExample from "/snippets/pages-router/catch-all-makeswift-component.mdx";
-import AppCatchAllExample from "/snippets/app-router/catch-all-makeswift-component.mdx";
-
 ## Props
 
 1. <ParamField query="snapshot" type="Snapshot" required>
      A Makeswift snapshot to render.
    </ParamField>
 2. <ParamField query="name" type="string" required>
-     The name of the component as displayed in the Visual Builder.
+     The label of the component to be used in the Visual Builder.
    </ParamField>
 3. <ParamField query="type" type="string" required>
      The type of the registered Makeswift component.
    </ParamField>
 
-## Example
+## Examples
 
-### Embedded component
+`<MakeswiftComponent>` can be used to render editable components and entire Makeswift pages.
 
-The following example embeds a Makeswift component in a Next.js page.
+### Editable components
 
-```tsx
-import { MakeswiftComponent } from "@makeswift/runtime/next";
+The following example creates an editable Makeswift component inside of a Next.js page.
 
-const productDetailSnapshot = await client.getComponentSnapshot(
-  `${slug}-product`,
-  {
-    siteVersion: getSiteVersion(),
-  }
-);
+First, you'll need a base component that accepts `content` as a prop.
 
-return (
-  <MakeswiftComponent
-    snapshot={snapshot}
-    name="Component Name"
-    type="component-type"
-  />
-);
+```tsx @/components/container/my-container.tsx
+type Props = {
+  className?: string;
+  content: ReactNode;
+};
+
+export const MyContainer = ({ content }: Props) => {
+  return <div>{content}</div>;
+};
 ```
 
-### App Router
+Next, this component needs to be registered with Makeswift. This example uses the [`Slot`](/developer/reference/controls/slot) control for the `content` property which matches the name of the prop defined in `MyContainer`.
 
-The following example sets up a [catch all dynamic route](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments) in the app router under `[[...path]]/page.tsx`.
+```tsx @/components/container/my-container.makeswift.ts
+import { runtime } from "@/makeswift/runtime";
+import { Slot, Style } from "@makeswift/runtime/controls";
+import { MyContainer } from "./my-container";
 
-<AppCatchAllExample />
+export const MY_CONTAINER_TYPE = "my-container";
 
-### Pages Router
+runtime.registerComponent(MyContainer, {
+  type: MY_CONTAINER_TYPE,
+  label: "My Container",
+  props: {
+    content: Slot(),
+  },
+});
+```
 
-The following example sets up a [catch all dynamic route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) in the pages router under `[[...path]].tsx`.
+import NamingConventions from "/snippets/naming-conventions.mdx";
 
-<PagesCatchAllExample />
+<NamingConventions />
+
+Then, you'll need to retrieve the snapshot of the component from the Makeswift API by calling [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot.mdx) with a unique id and pass that snapshot to the `<MakeswiftComponent>` component.
+
+```tsx @/app/my-page.tsx
+import { MakeswiftComponent } from "@makeswift/runtime/next";
+import { getSiteVersion } from "@makeswift/runtime/next/server";
+import { MY_CONTAINER_TYPE } from "@/components/container/my-container.makeswift";
+import { client } from "@/makeswift/client";
+
+export default async function Product() {
+  const myContainerSnapshot = await client.getComponentSnapshot(
+    `my-container-id`,
+    {
+      siteVersion: getSiteVersion(),
+    }
+  );
+
+  return (
+    <MakeswiftComponent
+      snapshot={myContainerSnapshot}
+      name={`My Container`}
+      type={MY_CONTAINER_TYPE}
+    />
+  );
+}
+```
+
+### Pages
+
+We are in the process of finalizing our APIs. For generating entire pages, you can use the deprecated [Page](/developer/reference/components/page) component until new components are finalized.

--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -1,49 +1,52 @@
 ---
 title: "<MakeswiftComponent>"
-description: The `<MakeswiftComponent>` component takes a Makeswift snapshot and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
+description: The `<MakeswiftComponent>` component takes a `MakeswiftComponentSnapshot` (returned from calling [getComponentSnapshot](/developer/reference/client/get-component-snapshot)) and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
 ---
+
+<Warning>
+  This API is a WIP and is subject to change. To use this API, you can use the
+  following version of the Makeswift runtime: `0.0.0-snapshot-20241113160601`
+</Warning>
 
 ## Props
 
 1. <ParamField query="snapshot" type="Snapshot" required>
      A Makeswift snapshot to render.
    </ParamField>
-2. <ParamField query="name" type="string" required>
-     The label of the component to be used in the Visual Builder.
+2. <ParamField query="label" type="string" required>
+     The name of the component to be used in the Visual Builder.
    </ParamField>
 3. <ParamField query="type" type="string" required>
      The type of the registered Makeswift component.
    </ParamField>
+4. <ParamField query="fallback" type="string">
+     The type of the registered Makeswift component.
+   </ParamField>
 
-## Examples
+## Example
 
-`<MakeswiftComponent>` can be used to render editable components and entire Makeswift pages.
+The following example registers a `MakeswiftComponent` that allows the user to add content to a container using the Visual Builder.
 
-### Editable components
-
-The following example creates an editable Makeswift component inside of a Next.js page.
-
-First, you'll need a base component that accepts `content` as a prop.
+First, you'll need a React component. Here, we're going to use one that has a single `children` prop, but you can customize the component and its props as needed.
 
 ```tsx @/components/container/my-container.tsx
 type Props = {
-  className?: string;
-  content: ReactNode;
+  children: ReactNode;
 };
 
-export const MyContainer = ({ content }: Props) => {
-  return <div>{content}</div>;
-};
+export default async function MyContainer({ children }: Props) {
+  return <div>{children}</div>;
+}
 ```
 
-Next, this component needs to be registered with Makeswift. This example uses the [`Slot`](/developer/reference/controls/slot) control for the `content` property which matches the name of the prop defined in `MyContainer`.
+Next, this component needs to be registered with Makeswift. This example uses the [`Slot`](/developer/reference/controls/slot) control for a `content` property. Notice this `content` property matches the name of the prop defined in the `MyContainer` component.
 
 ```tsx @/components/container/my-container.makeswift.ts
 import { runtime } from "@/makeswift/runtime";
-import { Slot, Style } from "@makeswift/runtime/controls";
+import { Slot } from "@makeswift/runtime/controls";
 import { MyContainer } from "./my-container";
 
-export const MY_CONTAINER_TYPE = "my-container";
+export const MY_CONTAINER_TYPE = "my-container"; //unique id for the registered component
 
 runtime.registerComponent(MyContainer, {
   type: MY_CONTAINER_TYPE,
@@ -54,36 +57,37 @@ runtime.registerComponent(MyContainer, {
 });
 ```
 
-import NamingConventions from "/snippets/naming-conventions.mdx";
-
-<NamingConventions />
+<Note>
+  Each time you create a registered component, you'll need to import it into
+  both your `layout.tsx` file and your `makeswift/provider.tsx` file.
+</Note>
 
 Then, you'll need to retrieve the snapshot of the component from the Makeswift API by calling [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot.mdx) with a unique id and pass that snapshot to the `<MakeswiftComponent>` component.
 
-```tsx @/app/my-page.tsx
+For the `MakeswiftComponent`, you'll need to pass the `snapshot`, `label`, and `type`. This `type` should match the `type` property of the registered component.
+
+Here, the `MakeswiftComponent` is being rendered on a page with the route `/my-page`.
+
+```tsx @/app/my-page/page.tsx
 import { MakeswiftComponent } from "@makeswift/runtime/next";
 import { getSiteVersion } from "@makeswift/runtime/next/server";
 import { MY_CONTAINER_TYPE } from "@/components/container/my-container.makeswift";
 import { client } from "@/makeswift/client";
 
-export default async function Product() {
+export default async function Page() {
   const myContainerSnapshot = await client.getComponentSnapshot(
-    `my-container-id`,
-    {
-      siteVersion: getSiteVersion(),
-    }
+    `my-container-id`, //id of the component rendered on the page
+    { siteVersion: await getSiteVersion() }
   );
 
   return (
     <MakeswiftComponent
       snapshot={myContainerSnapshot}
-      name={`My Container`}
-      type={MY_CONTAINER_TYPE}
+      label={`My Container`}
+      type={MY_CONTAINER_TYPE} //this should match the type property of the registered component
     />
   );
 }
 ```
 
-### Pages
-
-We are in the process of finalizing our APIs. For generating entire pages, you can use the deprecated [Page](/developer/reference/components/page) component until new components are finalized.
+To see this in the builder, you'll need to navigate to `/my-page` within the URL bar. This page won't be autopopulated in the builder, so you'll need to manually navigate to it.

--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -39,7 +39,7 @@ export default async function MyContainer({ children }: Props) {
 }
 ```
 
-Next, this component needs to be registered with Makeswift. This example uses the [`Slot`](/developer/reference/controls/slot) control for a `content` property. Notice this `content` property matches the name of the prop defined in the `MyContainer` component.
+Next, this component needs to be registered with Makeswift. This example uses the [`Slot`](/developer/reference/controls/slot) control for a `children` property. Notice this `chlidren` property matches the name of the prop defined in the `MyContainer` component.
 
 ```tsx @/components/container/my-container.makeswift.ts
 import { runtime } from "@/makeswift/runtime";
@@ -52,7 +52,7 @@ runtime.registerComponent(MyContainer, {
   type: MY_CONTAINER_TYPE,
   label: "My Container",
   props: {
-    content: Slot(),
+    children: Slot(),
   },
 });
 ```

--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -1,0 +1,56 @@
+---
+title: "<MakeswiftComponent>"
+description: The `<MakeswiftComponent>` component takes a Makeswift snapshot and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
+---
+
+import PagesCatchAllExample from "/snippets/pages-router/catch-all-makeswift-component.mdx";
+import AppCatchAllExample from "/snippets/app-router/catch-all-makeswift-component.mdx";
+
+## Props
+
+1. <ParamField query="snapshot" type="Snapshot" required>
+     A Makeswift snapshot to render.
+   </ParamField>
+2. <ParamField query="name" type="string" required>
+     The name of the component as displayed in the Visual Builder.
+   </ParamField>
+3. <ParamField query="type" type="string" required>
+     The type of the registered Makeswift component.
+   </ParamField>
+
+## Example
+
+### Embedded component
+
+The following example embeds a Makeswift component in a Next.js page.
+
+```tsx
+import { MakeswiftComponent } from "@makeswift/runtime/next";
+
+const productDetailSnapshot = await client.getComponentSnapshot(
+  `${slug}-product`,
+  {
+    siteVersion: getSiteVersion(),
+  }
+);
+
+return (
+  <MakeswiftComponent
+    snapshot={snapshot}
+    name="Component Name"
+    type="component-type"
+  />
+);
+```
+
+### App Router
+
+The following example sets up a [catch all dynamic route](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments) in the app router under `[[...path]]/page.tsx`.
+
+<AppCatchAllExample />
+
+### Pages Router
+
+The following example sets up a [catch all dynamic route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments) in the pages router under `[[...path]].tsx`.
+
+<PagesCatchAllExample />

--- a/developer/reference/components/page.mdx
+++ b/developer/reference/components/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "<Page>"
+title: "<Page> (deprecated)"
 description: The `<Page>` component takes a Makeswift snapshot and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
 ---
 

--- a/developer/reference/components/page.mdx
+++ b/developer/reference/components/page.mdx
@@ -1,10 +1,14 @@
 ---
-title: "<Page> (deprecated)"
+title: "<Page>"
 description: The `<Page>` component takes a Makeswift snapshot and renders React elements using [components registered](/developer/reference/runtime/register-component) with the runtime.
 ---
 
 import PagesCatchAllExample from "/snippets/pages-router/catch-all.mdx";
 import AppCatchAllExample from "/snippets/app-router/catch-all.mdx";
+
+<Warning>
+  This component is deprecated. We recommend using [\<MakeswiftComponent\>](/developer/reference/components/makeswift-component) instead.
+</Warning>
 
 ## Props
 

--- a/mint.json
+++ b/mint.json
@@ -120,20 +120,38 @@
 
     {
       "group": "Get started",
-      "pages": ["developer/quickstart", "developer/concepts"]
-    },
-    {
-      "group": "App Router",
       "pages": [
-        "developer/app-router/installation",
-        "developer/app-router/localization"
+        "developer/quickstart",
+        {
+          "group": "Installation",
+          "pages": [
+            "developer/app-router/installation",
+            "developer/pages-router/installation"
+          ]
+        },
+        "developer/concepts"
       ]
     },
     {
-      "group": "Pages Router",
+      "group": "Guides",
       "pages": [
-        "developer/pages-router/installation",
-        "developer/pages-router/localization"
+        {
+          "group": "Caching",
+          "pages": [
+            "developer/caching/overview",
+            "developer/caching/time-based-revalidation",
+            "developer/caching/tag-based-revalidation"
+          ]
+        },
+        {
+          "group": "Localization",
+          "pages": [
+            "developer/app-router/localization",
+            "developer/pages-router/localization"
+          ]
+        },
+        "developer/guides/troubleshooting",
+        "developer/guides/environments"
       ]
     },
     {
@@ -192,13 +210,7 @@
         }
       ]
     },
-    {
-      "group": "Guides",
-      "pages": [
-        "developer/guides/troubleshooting",
-        "developer/guides/environments"
-      ]
-    },
+
     {
       "group": "Integrations",
       "pages": ["developer/integrations/bigcommerce-catalyst"]

--- a/mint.json
+++ b/mint.json
@@ -142,8 +142,9 @@
         {
           "group": "Components",
           "pages": [
-            "developer/reference/components/page",
-            "developer/reference/components/react-runtime-provider"
+            "developer/reference/components/makeswift-component",
+            "developer/reference/components/react-runtime-provider",
+            "developer/reference/components/page"
           ]
         },
         {
@@ -171,8 +172,9 @@
             "developer/reference/client/constructor",
             "developer/reference/client/get-pages",
             "developer/reference/client/get-sitemap",
-            "developer/reference/client/get-page-snapshot",
-            "developer/reference/client/get-site-version"
+            "developer/reference/client/get-component-snapshot",
+            "developer/reference/client/get-site-version",
+            "developer/reference/client/get-page-snapshot"
           ]
         },
         "developer/reference/makeswift-api-handler",

--- a/mint.json
+++ b/mint.json
@@ -143,8 +143,7 @@
           "group": "Components",
           "pages": [
             "developer/reference/components/makeswift-component",
-            "developer/reference/components/react-runtime-provider",
-            "developer/reference/components/page"
+            "developer/reference/components/react-runtime-provider"
           ]
         },
         {
@@ -171,10 +170,8 @@
           "pages": [
             "developer/reference/client/constructor",
             "developer/reference/client/get-pages",
-            "developer/reference/client/get-sitemap",
             "developer/reference/client/get-component-snapshot",
-            "developer/reference/client/get-site-version",
-            "developer/reference/client/get-page-snapshot"
+            "developer/reference/client/get-site-version"
           ]
         },
         "developer/reference/makeswift-api-handler",
@@ -183,6 +180,14 @@
           "pages": [
             "developer/reference/runtime/constructor",
             "developer/reference/runtime/register-component"
+          ]
+        },
+        {
+          "group": "Legacy APIs",
+          "pages": [
+            "developer/reference/components/page",
+            "developer/reference/client/get-page-snapshot",
+            "developer/reference/client/get-sitemap"
           ]
         }
       ]

--- a/snippets/app-router/catch-all-makeswift-component.mdx
+++ b/snippets/app-router/catch-all-makeswift-component.mdx
@@ -1,0 +1,28 @@
+```tsx src/app/[[...path]]/page.tsx
+import { getSiteVersion } from "@makeswift/runtime/next/server";
+import { notFound } from "next/navigation";
+import { MakeswiftComponent } from "@makeswift/runtime/next";
+
+import { client } from "@/makeswift/client";
+
+type ParsedUrlQuery = { path?: string[] };
+
+export async function generateStaticParams() {
+  const pages = await client.getPages().toArray();
+
+  return pages.map((page) => ({
+    path: page.path.split("/").filter((segment) => segment !== ""),
+  }));
+}
+
+export default async function Page({ params }: { params: ParsedUrlQuery }) {
+  const path = "/" + (params?.path ?? []).join("/");
+  const snapshot = await client.getComponentSnapshot(path, {
+    siteVersion: getSiteVersion(),
+  });
+
+  if (snapshot == null) return notFound();
+
+  return <MakeswiftComponent snapshot={snapshot} name="" type="" />;
+}
+```

--- a/snippets/callouts/installation-requirement.mdx
+++ b/snippets/callouts/installation-requirement.mdx
@@ -1,0 +1,5 @@
+<Note>
+  This guide assumes you have already followed the [Installation
+  guide](/developer/app-router/installation) guide. If you haven't, please do so
+  before continuing.
+</Note>

--- a/snippets/pages-router/catch-all-makeswift-component.mdx
+++ b/snippets/pages-router/catch-all-makeswift-component.mdx
@@ -1,0 +1,84 @@
+<CodeGroup>
+
+```tsx src/pages/[[...path]].tsx
+import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
+
+import {
+  Makeswift,
+  Page as MakeswiftPage,
+  PageProps,
+} from "@makeswift/runtime/next";
+
+import { client } from "@/makeswift/client";
+
+export const getStaticPaths = (async () => {
+  const pages = await client.getPages();
+
+  return {
+    paths: pages.map((page) => ({
+      params: {
+        path: page.path.split("/").filter((segment) => segment !== ""),
+      },
+    })),
+    fallback: "blocking",
+  };
+}) satisfies GetStaticPaths;
+
+export const getStaticProps = (async ({ params, previewData }) => {
+  if (params == null) return { notFound: true };
+
+  const path = Array.isArray(params.path) ? "/" + params.path.join("/") : "/";
+
+  const snapshot = await client.getComponentSnapshot(path, {
+    siteVersion: Makeswift.getSiteVersion(previewData),
+  });
+
+  if (snapshot == null) return { notFound: true };
+
+  return { props: { snapshot } };
+}) satisfies GetStaticProps<PageProps>;
+
+export default function Page({
+  snapshot,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return <MakeswiftComponent snapshot={snapshot} name="" type="" />;
+}
+```
+
+```jsx src/pages/[[...path]].jsx
+import { Makeswift, Page as MakeswiftPage } from "@makeswift/runtime/next";
+
+import { client } from "@/makeswift/client";
+
+export async function getStaticPaths() {
+  const pages = await client.getPages();
+
+  return {
+    paths: pages.map((page) => ({
+      params: {
+        path: page.path.split("/").filter((segment) => segment !== ""),
+      },
+    })),
+    fallback: "blocking",
+  };
+}
+
+export async function getStaticProps({ params, previewData }) {
+  if (params == null) return { notFound: true };
+
+  const path = "/" + (params.path ?? []).join("/");
+  const snapshot = await client.getComponentSnapshot(path, {
+    siteVersion: Makeswift.getSiteVersion(previewData),
+  });
+
+  if (snapshot == null) return { notFound: true };
+
+  return { props: { snapshot } };
+}
+
+export default function Page({ snapshot }) {
+  return <MakeswiftComponent snapshot={snapshot} name="" type="" />;
+}
+```
+
+</CodeGroup>


### PR DESCRIPTION
- add new pages for `<MakeswiftComponent>` and `getComponentSnapshot()`
- mark `<Page>` and `getPageSnapshot()` as deprecated