### PR TITLE
fix: hide scheduled publishes video

### DIFF
--- a/product/publishing.mdx
+++ b/product/publishing.mdx
@@ -79,18 +79,6 @@ You can also publish changes made to existing site resources without needing to 
 
 ## Scheduling publishes
 
-<Frame>
-  <video
-    autoPlay
-    muted
-    controls
-    playsInline
-    title="Create new site from template"
-    className="w-full aspect-video"
-    src="/images/publishing/scheduled-publishing.mp4"
-  ></video>
-</Frame>
-
 <Warning>
   Scheduled publishes are currently only available on certain paid plans. Refer
   to the [Plans](/product/workspace/plans) page for full details.


### PR DESCRIPTION
Video upload didn't appear to work with Mintlify, so we are removing the video for now until we figure out why.