### PR TITLE
Add Upgrade Guide for 0.23

### DIFF
--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -90,7 +90,7 @@ export function Header({ className, links, logo }: Props) {
 
 ### Registering with Makeswift
 
-Next, this component needs to be registered with Makeswift. This example registers the same three properties: `className`, `logo`, and `links`. Notice these property property names match the property names defined in the `Header` component.
+Next, this component needs to be registered with Makeswift. This example registers the same three properties: `className`, `logo`, and `links`. Notice these property names match the property names defined in the `Header` component.
 
 <Note>
   In `registerComponent` the `hidden` property is set to `true` which hides it

--- a/developer/reference/makeswift-api-handler.mdx
+++ b/developer/reference/makeswift-api-handler.mdx
@@ -3,9 +3,9 @@ title: "MakeswiftApiHandler"
 description: An API route for Makeswift that adds support for [preview mode](https://nextjs.org/docs/pages/building-your-application/configuring/preview-mode), [on-demand revalidation](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration#on-demand-revalidation), and other features that make Makeswift work seamlessly with your Next.js app.
 ---
 
-import FontsExample from '/snippets/reference/fonts.mdx'
-import PagesApiHandlerExample from '/snippets/pages-router/api-handler.mdx'
-import AppApiHandlerExample from '/snippets/app-router/api-handler.mdx'
+import FontsExample from "/snippets/reference/fonts.mdx";
+import PagesApiHandlerExample from "/snippets/pages-router/api-handler.mdx";
+import AppApiHandlerExample from "/snippets/app-router/api-handler.mdx";
 
 ## Arguments
 
@@ -15,6 +15,9 @@ import AppApiHandlerExample from '/snippets/app-router/api-handler.mdx'
 2. <ParamField query="options" type="object">
      Options for site version and locale.
      <Expandable>
+       <ParamField query="runtime" type="ReactRuntime" required>
+         An instance of [ReactRuntime](/developer/reference/runtime/constructor)
+       </ParamField>
        <ParamField query="getFonts" type="() => FontFamily[]">
         This function is called when the builder requests the list of fonts available for the site. The function should return an array of `FontFamily` objects.
 

--- a/developer/reference/makeswift-api-handler.mdx
+++ b/developer/reference/makeswift-api-handler.mdx
@@ -12,7 +12,7 @@ import AppApiHandlerExample from "/snippets/app-router/api-handler.mdx";
 1. <ParamField query="apiKey" type="string" required>
      The API key for the Makeswift site.
    </ParamField>
-2. <ParamField query="options" type="object">
+2. <ParamField query="options" type="object" required>
      Options for site version and locale.
      <Expandable>
        <ParamField query="runtime" type="ReactRuntime" required>

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -39,6 +39,10 @@ The available values are sourced from our Google Fonts integration within Makesw
 
 ### Built-in elements
 
-This release introduces support for **built-in elements**, which are hard-coded instances of components in a page that can still be edited in the Visual Builder. To support this, we've included to new components, [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) and [`<Slot>`](/developer/reference/components/slot), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
+This release introduces support for **built-in elements** which allow developers to define editable regions within a page. These regions are hard-coded instances of components using the new [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) API. This means these can't elements can't be removed by users in the Visual Builder, but they can be edited based on the properties developers decide to expose.
+
+A good example of this would be a `<Header>` component that you want to be included on every page. Instead of the user having to drag and drop that component visually onto each page, the developer can make this a built-in element in the page template. This way, the `<Header>` will show up on every page without manually having to add it. More details in [this example](/developer/reference/components/makeswift-component#example).
+
+To support this, we've included to new components, [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) and [`<Slot>`](/developer/reference/components/slot), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
 
 Check out our new [editable-regions example](https://github.com/makeswift/makeswift/tree/main/examples/editable-regions) to learn how to combine these APIs to create a set of dynamic pages with a visually editable header, footer, and a slot for the main content.

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -4,22 +4,41 @@ title: Upgrading to 0.23.0
 
 If you haven't upgraded to `0.20.0` please read the [upgrading guide](/developer/upgrading/0.20.0).
 
-`v0.23.0` of the runtime introduces new runtime internals, 2 new components, and a few breaking changes.
+`v0.23.0` of the runtime introduces new runtime internals, new components, and a few breaking changes. Refer to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift/runtime%400.23.0) for more details.
 
 ## Breaking Changes
 
 ### `MakeswiftApiHandler` requires instance of `ReactRuntime`
 
-To initialize an instance of the `MakeswiftApiHandler`, you must now pass an instance of the [ReactRuntime](/developer/reference/runtime/constructor). See [MakeswiftApiHandler](/developer/reference/makeswift-api-handler) for full details.
+To initialize an instance of the [MakeswiftApiHandler](/developer/reference/makeswift-api-handler), you must now pass an instance of the [ReactRuntime](/developer/reference/runtime/constructor). See [MakeswiftApiHandler](/developer/reference/makeswift-api-handler) for full details.
 
-### API changes to support multi-document pages
+### New props for `ReactRuntimeProvider`
 
-The [ReactRuntimeProvider](/developer/reference/components/react-runtime-provider) component now accepts two new props: `previewMode` and `locale`. `previewMode` is required in all cases, while `locale` is required if your site supports more than one locale. Check out our updated [App Router](/developer/app-router/installation) and [Pages Router](/developer/pages-router/installation) installation guides to learn how to provide these props in both setups.
+In order to support the new [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) API (details [below](#built-in-elements)), which can be rendered multiple times on a Next.js page, we had to make some changes to the Makeswift provider. The [ReactRuntimeProvider](/developer/reference/components/react-runtime-provider) component now accepts two new props: `previewMode` and `locale`. `previewMode` is required in all cases, while `locale` is required if your site supports more than one locale.
 
-## Editable page regions
+Check out our updated [App Router](/developer/app-router/installation) and [Pages Router](/developer/pages-router/installation) installation guides to learn how to provide these props in both setups.
 
-This release introduces support for editable page regions through the new page regions API, which includes two built-in React components, [`<Slot>`](/developer/reference/components/slot) and [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
+## Deprecated items
 
-Check out our new [editable-regions-example](https://github.com/makeswift/makeswift/tree/main/examples/editable-regions) to learn how to combine these APIs to create a set of dynamic pages with a visually editable header, footer, and a slot for the main content.
+### `Shape` control
 
-Here is the link to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift/runtime%400.23.0).
+The [Shape](/developer/reference/controls/shape) control has been deprecated and will be removed in a future release. We recommend using the new [Group](/developer/reference/controls/group) control going forward.
+
+## New controls
+
+### `Group` control
+
+We've added a new [Group](/developer/reference/controls/group) control which is designed to be a more versatile replacement for the [Shape](/developer/reference/controls/shape) control.
+
+### `Font` control
+
+We've added a new [Font](/developer/reference/controls/font) control which let's you select a `fontFamily`, `fontStyle`, and `fontWeight`.
+The available values are sourced from our Google Fonts integration within Makeswift and from the variants you pass to `getFonts` in your [MakeswiftApiHandler](/developer/reference/makeswift-api-handler).
+
+## New Apis
+
+### Built-in elements
+
+This release introduces support for **built-in elements**, which are hard-coded instances of components in a page that can still be edited in the Visual Builder. To support this, we've included to new components, [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) and [`<Slot>`](/developer/reference/components/slot), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
+
+Check out our new [editable-regions example](https://github.com/makeswift/makeswift/tree/main/examples/editable-regions) to learn how to combine these APIs to create a set of dynamic pages with a visually editable header, footer, and a slot for the main content.

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -4,41 +4,22 @@ title: Upgrading to 0.23.0
 
 If you haven't upgraded to `0.20.0` please read the [upgrading guide](/developer/upgrading/0.20.0).
 
-`v0.23.0` of the runtime introduces a few new components and breaking changes.
+`v0.23.0` of the runtime introduces new runtime internals, 2 new components, and a few breaking changes.
 
-1.  Attempting to create a control with arbitrary configuration options will now
-    result in a TypeScript compilation error:
+## Breaking Changes
 
-    ```typescript
-    import { Number } from "@makeswift/runtime/controls";
+### `MakeswiftApiHandler` requires instance of `ReactRuntime`
 
-    const num = Number({ foo: "bar" }); // TS error, `foo` is not a valid `Number` param
-    ```
+To initialize an instance of the `MakeswiftApiHandler`, you must now pass an instance of the [ReactRuntime](/developer/reference/runtime/constructor). See [MakeswiftApiHandler](/developer/reference/makeswift-api-handler) for full details.
 
-    Prior to this version, the arbitrary options were silently ignored.
+### API changes to support multi-document pages
 
-2.  The `Select` control now requires `options` to be a readonly array with at
-    least one entry. If you are not defining your options inline, you may need
-    to declare the options `as const`.
+The [ReactRuntimeProvider](/developer/reference/components/react-runtime-provider) component now accepts two new props: `previewMode` and `locale`. `previewMode` is required in all cases, while `locale` is required if your site supports more than one locale. Check out our updated [App Router](/developer/app-router/installation) and [Pages Router](/developer/pages-router/installation) installation guides to learn how to provide these props in both setups.
 
-    ```typescript
-    import { Select } from "@makeswift/runtime/controls";
+## Editable page regions
 
-    const sel = Select({
-      label: "Select",
-      options: [], // TS error, non-empty array is required
-    });
-    ```
+This release introduces support for editable page regions through the new page regions API, which includes two built-in React components, [`<Slot>`](/developer/reference/components/slot) and [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
 
-    Previously, the `options` array was allowed to be empty.
+Check out our new [editable-regions-example](https://github.com/makeswift/makeswift/tree/main/examples/editable-regions) to learn how to combine these APIs to create a set of dynamic pages with a visually editable header, footer, and a slot for the main content.
 
-Additionally, several undocumented internal types and functions are no longer
-being exported from the package, as they were not intended for our public API.
-
-Lastly, this version of the runtime now validates control configuration at
-runtime. If you were using the runtime without TypeScript, you may see errors in
-the console if you pass invalid options to a control. We recommend reading our
-[controls documentation](/developer/reference/controls) to ensure proper usage,
-or if possible, using TypeScript to catch these errors ahead of time.
-
-Here is the link to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.20.0).
+Here is the link to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift/runtime%400.23.0).

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -1,0 +1,44 @@
+---
+title: Upgrading to 0.23.0
+---
+
+If you haven't upgraded to `0.20.0` please read the [upgrading guide](/developer/upgrading/0.20.0).
+
+`v0.23.0` of the runtime introduces a few new components and breaking changes.
+
+1.  Attempting to create a control with arbitrary configuration options will now
+    result in a TypeScript compilation error:
+
+    ```typescript
+    import { Number } from "@makeswift/runtime/controls";
+
+    const num = Number({ foo: "bar" }); // TS error, `foo` is not a valid `Number` param
+    ```
+
+    Prior to this version, the arbitrary options were silently ignored.
+
+2.  The `Select` control now requires `options` to be a readonly array with at
+    least one entry. If you are not defining your options inline, you may need
+    to declare the options `as const`.
+
+    ```typescript
+    import { Select } from "@makeswift/runtime/controls";
+
+    const sel = Select({
+      label: "Select",
+      options: [], // TS error, non-empty array is required
+    });
+    ```
+
+    Previously, the `options` array was allowed to be empty.
+
+Additionally, several undocumented internal types and functions are no longer
+being exported from the package, as they were not intended for our public API.
+
+Lastly, this version of the runtime now validates control configuration at
+runtime. If you were using the runtime without TypeScript, you may see errors in
+the console if you pass invalid options to a control. We recommend reading our
+[controls documentation](/developer/reference/controls) to ensure proper usage,
+or if possible, using TypeScript to catch these errors ahead of time.
+
+Here is the link to the [official release notes](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.20.0).

--- a/mint.json
+++ b/mint.json
@@ -151,7 +151,20 @@
           ]
         },
         "developer/guides/troubleshooting",
-        "developer/guides/environments"
+        "developer/guides/environments",
+        {
+          "group": "Upgrading",
+          "pages": [
+            "developer/upgrading/0.23.0",
+            "developer/upgrading/0.20.0",
+            "developer/upgrading/0.19.0",
+            "developer/upgrading/0.18.0",
+            "developer/upgrading/0.15.0",
+            "developer/upgrading/0.14.0",
+            "developer/upgrading/0.13.0",
+            "developer/upgrading/0.9.0"
+          ]
+        }
       ]
     },
     {
@@ -222,18 +235,6 @@
     {
       "group": "Integrations",
       "pages": ["developer/integrations/bigcommerce-catalyst"]
-    },
-    {
-      "group": "Upgrading",
-      "pages": [
-        "developer/upgrading/0.20.0",
-        "developer/upgrading/0.19.0",
-        "developer/upgrading/0.18.0",
-        "developer/upgrading/0.15.0",
-        "developer/upgrading/0.14.0",
-        "developer/upgrading/0.13.0",
-        "developer/upgrading/0.9.0"
-      ]
     }
   ],
   "footerSocials": {

--- a/snippets/reference/fonts.mdx
+++ b/snippets/reference/fonts.mdx
@@ -1,12 +1,18 @@
 <CodeGroup>
 
 ```ts pages/api/[...makeswift].ts
-import { MakeswiftApiHandler } from "@makeswift/runtime/next/server"
-import { strict } from "assert"
+import { MakeswiftApiHandler } from "@makeswift/runtime/next/server";
+import { strict } from "assert";
 
-strict(process.env.MAKESWIFT_SITE_API_KEY, "MAKESWIFT_SITE_API_KEY is required")
+import { runtime } from "@/makeswift/runtime";
+
+strict(
+  process.env.MAKESWIFT_SITE_API_KEY,
+  "MAKESWIFT_SITE_API_KEY is required"
+);
 
 export default MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
+  runtime,
   getFonts() {
     return [
       {
@@ -39,18 +45,18 @@ export default MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
           },
         ],
       },
-    ]
+    ];
   },
-})
+});
 ```
 
 ```tsx _app.tsx
-import { AppProps } from "next/app"
-import { Spline_Sans, Spline_Sans_Mono } from "next/font/google"
+import { AppProps } from "next/app";
+import { Spline_Sans, Spline_Sans_Mono } from "next/font/google";
 
-import clsx from "clsx"
+import clsx from "clsx";
 
-import "../styles/globals.css"
+import "../styles/globals.css";
 
 const splineSans = Spline_Sans({
   subsets: ["latin"],
@@ -63,22 +69,22 @@ const splineSans = Spline_Sans({
     "Arial",
     "sans-serif",
   ],
-})
+});
 const splineSansMono = Spline_Sans_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
   fallback: ["Courier New"],
-})
+});
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <main className={clsx(splineSans.variable, splineSansMono.variable)}>
       <Component {...pageProps} />
     </main>
-  )
+  );
 }
 
-export default MyApp
+export default MyApp;
 ```
 
 </CodeGroup>


### PR DESCRIPTION
- added new guide
- moved upgrade guides to nested section under `guides` in side navbar
- updated `MakeswiftApiHandler` props to reflect new changes