### PR TITLE
Add docker deploy Doc

### DIFF
--- a/developer/guides/deploying/docker.mdx
+++ b/developer/guides/deploying/docker.mdx
@@ -1,0 +1,27 @@
+---
+title: Docker
+description: "Learn how to deploy your Makeswift application with Docker."
+---
+
+## Prerequisites
+
+You'll need a Makeswift site. If you don't already have one, you can follow the [developer quickstart](/developer/quickstart) or [installation guide](/developer/app-router/installation) to get started.
+
+You'll also need to use [Makeswift runtime](https://www.npmjs.com/package/@makeswift/runtime?activeTab=readme) **version `0.23.2` or higher.**
+
+## Deploying
+
+Vercel has already documented how to deploy a Next.js application with Docker. The only change you have to make when deploying your Makeswift site is to your environment variables ([details below](#environment-variables)).
+
+Otherwise, you can follow the [Next.js with Docker](https://github.com/vercel/next.js/tree/canary/examples/with-docker) documentation.
+
+### Environment variables
+
+You'll need to include two environment variables in your Docker build: `MAKESWIFT_SITE_API_KEY` and `FORCE_HTTP`. These will need to be added in the `.env` file that is included in your Docker build or in the dashboard of your hosting provider.
+
+```bash
+MAKESWIFT_SITE_API_KEY=<YOUR_API_KEY>
+FORCE_HTTP=true
+```
+
+Your Makeswift API key can be found in the Makeswift Visual Builder under **Settings > Host**.

--- a/developer/guides/deploying/docker.mdx
+++ b/developer/guides/deploying/docker.mdx
@@ -24,4 +24,9 @@ MAKESWIFT_SITE_API_KEY=<YOUR_API_KEY>
 FORCE_HTTP=true
 ```
 
+<Note>
+  The `FORCE_HTTP` flag is only necessary to handle internal communication. This
+  **does not** affect your external domain name which should use `https`.
+</Note>
+
 Your Makeswift API key can be found in the Makeswift Visual Builder under **Settings > Host**.

--- a/developer/guides/deploying/overview.mdx
+++ b/developer/guides/deploying/overview.mdx
@@ -13,6 +13,6 @@ description: "Learn how to deploy your Makeswift application."
     Learn to deploy to Netlify
   </Card>
   <Card title="Docker" href="/developer/guides/deploying/docker">
-    Learn to deploy to Docker
+    Learn to deploy using Docker
   </Card>
 </CardGroup>

--- a/developer/guides/deploying/overview.mdx
+++ b/developer/guides/deploying/overview.mdx
@@ -12,4 +12,7 @@ description: "Learn how to deploy your Makeswift application."
   <Card title="Netlify" href="/developer/guides/deploying/netlify">
     Learn to deploy to Netlify
   </Card>
+  <Card title="Docker" href="/developer/guides/deploying/docker">
+    Learn to deploy to Docker
+  </Card>
 </CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -147,7 +147,8 @@
           "pages": [
             "developer/guides/deploying/overview",
             "developer/guides/deploying/vercel",
-            "developer/guides/deploying/netlify"
+            "developer/guides/deploying/netlify",
+            "developer/guides/deploying/docker"
           ]
         },
         "developer/guides/troubleshooting",


### PR DESCRIPTION
Added a doc for deploying using Docker. Primarily, this links to the existing Vercel documentation with two callouts on runtime version and environment variables.
![CleanShot 2025-01-30 at 10 42 48@2x](https://github.com/user-attachments/assets/011b0f81-7b6a-48a0-8a29-9aee4300c79d)
