### PR TITLE
fix: add components import to the API route snippets

### DIFF
--- a/snippets/app-router/api-handler.mdx
+++ b/snippets/app-router/api-handler.mdx
@@ -4,6 +4,9 @@ import { strict } from "assert";
 
 import { runtime } from "@/makeswift/runtime";
 
+// make custom components' data available for introspection
+import "@/makeswift/components";
+
 strict(
   process.env.MAKESWIFT_SITE_API_KEY,
   "MAKESWIFT_SITE_API_KEY is required"

--- a/snippets/pages-router/api-handler.mdx
+++ b/snippets/pages-router/api-handler.mdx
@@ -4,6 +4,9 @@ import { strict } from "assert";
 
 import { runtime } from "@/makeswift/runtime";
 
+// make custom components' data available for introspection
+import "@/makeswift/components";
+
 strict(
   process.env.MAKESWIFT_SITE_API_KEY,
   "MAKESWIFT_SITE_API_KEY is required"


### PR DESCRIPTION
The API route needs a components import, otherwise it won't know about any of the custom components and won't be able to introspect them/replace the resources.