### PR TITLE
fix: unreachable manifest doc

### DIFF
--- a/developer/messages/manifest-unreachable.mdx
+++ b/developer/messages/manifest-unreachable.mdx
@@ -17,18 +17,16 @@ Here is a list of things to check to make sure the host manifest is reachable
     Makeswift can only fetch the host manifest if your Next.js app is running. Make sure your Next.js app is running.
   </Step>
 
-{" "}
-
-<Step title="Check that the host URL is correct in the Makeswift host settings">
-  If your Next.js app is running, check that the host URL including the host
-  name and port are correct in the Makeswift host settings. Update the host URL
-  if necessary.
-  <Accordion title="Show me how">
-    <Frame>
-      <img src="/images/host-url.gif" alt="How to update the host url" />
-    </Frame>
-  </Accordion>
-</Step>
+  <Step title="Check that the host URL is correct in the Makeswift host settings">
+    If your Next.js app is running, check that the host URL including the host
+    name and port are correct in the Makeswift host settings. Update the host URL
+    if necessary.
+    <Accordion title="Show me how">
+      <Frame>
+        <img src="/images/host-url.gif" alt="How to update the host url" />
+      </Frame>
+    </Accordion>
+  </Step>
 
   <Step title="Check that your API key is passed to the Makeswift API handler">
     Makeswift fetches the manifest from an API handler in your Next.js app.
@@ -37,7 +35,6 @@ Here is a list of things to check to make sure the host manifest is reachable
 
     - [App Router installation guide](/developer/app-router/installation)
     - [Pages Router installation guide](/developer/pages-router/installation)
-
   </Step>
   
   <Step title="Check that the Makeswift API handler is set up">
@@ -46,6 +43,5 @@ Here is a list of things to check to make sure the host manifest is reachable
 
     - [App Router installation guide](/developer/app-router/installation)
     - [Pages Router installation guide](/developer/pages-router/installation)
-
   </Step>
 </Steps>


### PR DESCRIPTION
The {" "} was causing the issue of TypeError: Cannot read properties of undefined (reading 'title')

In this commit, I also format the indentation.

All other message docs look fine.

Before
<img width="1635" alt="image" src="https://github.com/user-attachments/assets/b1c80d2c-6c73-425e-bb85-969f14058cb7" />


After
<img width="1652" alt="image" src="https://github.com/user-attachments/assets/c449c32a-a744-4624-b9b9-b30cf0ef4c7e" />
