### PR TITLE
feat: add developer and product docs for cookies

### DIFF
--- a/developer/guides/how-to/setting-cookies.mdx
+++ b/developer/guides/how-to/setting-cookies.mdx
@@ -1,0 +1,142 @@
+---
+title: "Setting Cookies"
+description: Configuring cookies for use within the Makeswift Visual Builder
+---
+
+If your site relies on setting/reading cookies, you may experience some issues
+when interacting with your site within the Makeswift Visual Builder. This is
+because our builder loads your site within an `iframe`, so any cookies your site
+attempts to set are considered as [third-party
+cookies](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies).
+
+In order for your site to be able to set cookies that are compatible with the
+Makeswift Visual Builder, you may need to include certain attributes.
+
+## Minimum Attributes
+
+In order for a third-party cookie to be set, you'll need to specify the
+`SameSite=None;` and `Secure;`
+[attributes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#controlling_third-party_cookies_with_samesite)
+on your cookie.
+
+For example, let's say your site attempts to set a cookie client-side using
+`document.cookie`:
+
+```typescript
+document.cookie = "myCookie=1234;"
+```
+
+While this may work on your live site, it will not work in the builder because
+of the third-party restrictions. Let's update this cookie to use
+`SameSite=None;` and `Secure;`:
+
+```typescript
+document.cookie = "myCookie=1234; SameSite=None; Secure;"
+```
+
+This will now be able to be set in most browsers, assuming the user has the
+appropriate browser settings.
+
+Similarly, you may be setting cookies in a server response using the
+`Set-Cookie` header. For example, you may be using the [`cookies()` API from
+Next.js](https://nextjs.org/docs/app/api-reference/functions/cookies):
+
+```typescript
+import { cookies } from 'next/headers'
+ 
+export async function setCustomCookies() {
+  const cookieStore = await cookies()
+  cookieStore.set({
+    name: 'myCookie',
+    value: '1234',
+  })
+}
+```
+
+Again, the same attributes are necessary here:
+
+```typescript
+import { cookies } from 'next/headers'
+ 
+export async function setCustomCookies() {
+  const cookieStore = await cookies()
+  cookieStore.set({
+    name: 'myCookie',
+    value: '1234',
+    // Adding cross-site attribute below
+    sameSite: 'none',
+    secure: true,
+  })
+}
+```
+
+If you're setting a raw `Set-Cookie` header string on your response header, you
+can follow the same conventions as the client-side cookie string.
+
+## Partitioned Cookies (CHIPS)
+
+Nearly all major browsers have plans to fully deprecate third-party cookies in
+the near future. As a workaround, the [**Cookies Having Independent Partitioned
+State**
+(CHIPS)](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)
+spec was introduced. Partitioned cookies are keyed by both the domain of the
+third-party site that set them and the top-level site in which they were set. In
+Makeswift, your site is the one setting the cookie, and the top-level site would
+be the Visual Builder, `app.makeswift.com`. This means that any cookies set by
+your site within the builder are scoped to the builder! 
+
+To achieve this functionality, simply add a `Partitioned;` attribute whenever
+you set your cookies. Using our client-side example from above:
+
+```typescript
+document.cookie = "myCookie=1234; SameSite=None; Secure; Partitioned;"
+```
+
+And our Next.js `cookies()` example:
+
+```typescript
+import { cookies } from 'next/headers'
+ 
+export async function setCustomCookies() {
+  const cookieStore = await cookies()
+  cookieStore.set({
+    name: 'myCookie',
+    value: '1234',
+    sameSite: 'none',
+    secure: true,
+    partitioned: true
+    // ^^^ Cookie will now be partitioned when set on the client
+  })
+}
+```
+
+
+Partitioned cookies [are currently
+supported](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies#browser_compatibility)
+by Chrome and Firefox. Safari support is still in development.
+
+### Safari
+
+Since Safari still does not currently support partitioned cookies, the
+recommended way to have full cookie functionality within the builder is to
+[follow our guide](/product/troubleshooting/cookies#safari) to disable
+cross-site tracking prevention when using our editor.
+
+## Cookies by other libraries
+
+It's also possible that you're using an external package that sets its own
+cookies. For example, [middleware from the `next-intl`
+package](https://next-intl.dev/docs/routing/middleware) will attempt to set
+cookies for detected locales. For such cases, we recommend checking the docs of
+these tools to see if they allow for cookie attribute configuration. Continuing
+the `next-intl` example, we see that their [APIs offer
+customization](https://next-intl.dev/docs/routing#locale-cookie) of their locale
+detection cookie.
+
+If the third-party package you're using does not permit modifying cookie
+attributes, you may still be able to patch them retroactively using the Next.js
+`cookies()` API (if the cookies are set server-side), or by manually writing
+cookies with the appropriate attributes client-side. Whenever you make changes
+to how external packages set cookies, make sure to test that the cookie
+attribute changes don't impact the security or functionality of your cookies on
+your live site.

--- a/developer/guides/how-to/setting-cookies.mdx
+++ b/developer/guides/how-to/setting-cookies.mdx
@@ -23,7 +23,7 @@ For example, let's say your site attempts to set a cookie client-side using
 `document.cookie`:
 
 ```typescript
-document.cookie = "myCookie=1234;"
+document.cookie = "myCookie=1234;";
 ```
 
 While this may work on your live site, it will not work in the builder because
@@ -31,42 +31,42 @@ of the third-party restrictions. Let's update this cookie to use
 `SameSite=None;` and `Secure;`:
 
 ```typescript
-document.cookie = "myCookie=1234; SameSite=None; Secure;"
+document.cookie = "myCookie=1234; SameSite=None; Secure;";
 ```
 
 This will now be able to be set in most browsers, assuming the user has the
 appropriate browser settings.
 
 Similarly, you may be setting cookies in a server response using the
-`Set-Cookie` header. For example, you may be using the [`cookies()` API from
-Next.js](https://nextjs.org/docs/app/api-reference/functions/cookies):
+`Set-Cookie` header. For example, you may be using the [`cookies()`](https://nextjs.org/docs/app/api-reference/functions/cookies) API from
+Next.js:
 
 ```typescript
-import { cookies } from 'next/headers'
- 
+import { cookies } from "next/headers";
+
 export async function setCustomCookies() {
-  const cookieStore = await cookies()
+  const cookieStore = await cookies();
   cookieStore.set({
-    name: 'myCookie',
-    value: '1234',
-  })
+    name: "myCookie",
+    value: "1234",
+  });
 }
 ```
 
 Again, the same attributes are necessary here:
 
 ```typescript
-import { cookies } from 'next/headers'
- 
+import { cookies } from "next/headers";
+
 export async function setCustomCookies() {
-  const cookieStore = await cookies()
+  const cookieStore = await cookies();
   cookieStore.set({
-    name: 'myCookie',
-    value: '1234',
+    name: "myCookie",
+    value: "1234",
     // Adding cross-site attribute below
-    sameSite: 'none',
+    sameSite: "none",
     secure: true,
-  })
+  });
 }
 ```
 
@@ -83,33 +83,32 @@ spec was introduced. Partitioned cookies are keyed by both the domain of the
 third-party site that set them and the top-level site in which they were set. In
 Makeswift, your site is the one setting the cookie, and the top-level site would
 be the Visual Builder, `app.makeswift.com`. This means that any cookies set by
-your site within the builder are scoped to the builder! 
+your site within the builder are scoped to the builder!
 
 To achieve this functionality, simply add a `Partitioned;` attribute whenever
 you set your cookies. Using our client-side example from above:
 
 ```typescript
-document.cookie = "myCookie=1234; SameSite=None; Secure; Partitioned;"
+document.cookie = "myCookie=1234; SameSite=None; Secure; Partitioned;";
 ```
 
 And our Next.js `cookies()` example:
 
 ```typescript
-import { cookies } from 'next/headers'
- 
+import { cookies } from "next/headers";
+
 export async function setCustomCookies() {
-  const cookieStore = await cookies()
+  const cookieStore = await cookies();
   cookieStore.set({
-    name: 'myCookie',
-    value: '1234',
-    sameSite: 'none',
+    name: "myCookie",
+    value: "1234",
+    sameSite: "none",
     secure: true,
-    partitioned: true
+    partitioned: true,
     // ^^^ Cookie will now be partitioned when set on the client
-  })
+  });
 }
 ```
-
 
 Partitioned cookies [are currently
 supported](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies#browser_compatibility)
@@ -125,8 +124,7 @@ cross-site tracking prevention when using our editor.
 ## Cookies by other libraries
 
 It's also possible that you're using an external package that sets its own
-cookies. For example, [middleware from the `next-intl`
-package](https://next-intl.dev/docs/routing/middleware) will attempt to set
+cookies. For example, middleware from the [`next-intl`](https://next-intl.dev/docs/routing/middleware) package will attempt to set
 cookies for detected locales. For such cases, we recommend checking the docs of
 these tools to see if they allow for cookie attribute configuration. Continuing
 the `next-intl` example, we see that their [APIs offer

--- a/mint.json
+++ b/mint.json
@@ -68,7 +68,14 @@
     },
     {
       "group": "Guides",
-      "pages": ["product/localization", "product/publishing"]
+      "pages": [
+        "product/localization",
+        "product/publishing",
+        {
+          "group": "Troubleshooting",
+          "pages": ["product/troubleshooting/cookies"]
+        }
+      ]
     },
     {
       "group": "Reference",
@@ -152,8 +159,11 @@
           ]
         },
         {
-          "group": "How To",
-          "pages": ["developer/guides/how-to/built-in-components"]
+          "group": "How to",
+          "pages": [
+            "developer/guides/how-to/built-in-components",
+            "developer/guides/how-to/setting-cookies"
+          ]
         },
         "developer/guides/troubleshooting",
         "developer/guides/environments",

--- a/product/troubleshooting/cookies.mdx
+++ b/product/troubleshooting/cookies.mdx
@@ -1,0 +1,91 @@
+---
+title: "Cookies in Makeswift"
+description: Learn how to troubleshoot working with cookies inside the Makeswift Visual Builder.
+icon: "cookie-bite" iconType: "regular"
+---
+
+## What are Cookies?
+
+[Cookies](https://web.dev/articles/understanding-cookies) are a tool used by
+sites to set small pieces of data on the browser. Some features that often rely
+on cookies include:
+
+- Saving login data after a user logs in to a site
+- Storing what items a user has added to their shopping cart
+- Tracking user analytics and behavior
+
+If your site relies on setting cookies, you may notice some issues with how your
+site behaves when you load it in the Makeswift Visual Builder. This is because
+your site is embedded inside an `<iframe>` when it loads in our builder. When an
+embedded site (in this case, your site) is attempting to set a cookie, that
+cookie is considered by the browser as a [**third-party
+cookie**](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies).
+Modern web browsers have privacy restrictions on how third-party cookies are
+set. As a result, you may see issues related to cookies inside the builder, but
+not in your live page. 
+
+## Browser Settings
+
+If cookie related issues are impacting your editing experience, there's some
+ways you can modify your browser settings to allow third-party cookies to be
+set: We'll go over how for the major browsers:
+
+### Chrome / Brave / Arc
+
+Chrome (and other Chromium based browsers, like [Brave](https://brave.com/) and
+[Arc](https://arc.net/)) allow you to control whether specific sites can set
+third-party cookies. With their plan to soon disable all third-party cookies, it
+may be helpful to allow your site to set third-party cookies:
+
+1. In the URL bar, go to `chrome://settings/cookies`
+2. In the **Site allowed to use third party cookies** section, click the
+   **Add** button.
+3. A text input will appear that allows you to add a domain. Add your site's
+   domain. For example, if your host is on `example.com`, enter
+   `example.com` in the text input.
+   - You can also match your other subdomains, like `custom.example.com`, by
+   using a matcher: `[*.]example.com`.
+
+For more information on modifying Chrome's cookie permissions for you site, [see this
+article](https://support.google.com/chrome/answer/95647).
+
+<Warning>
+   Even with these browser settings, Chrome will still not allow sites to
+   set third-party cookies **unless the cookie has specific attributes**. For your
+   site, this means that your developer will have to make some changes to how
+   cookies are set. See the [Developer Settings](#developer-settings) section for
+   more details.
+</Warning>
+
+### Firefox
+
+Since 2021, Firefox automatically partitions third-party cookies, which means
+that any cookies your site sets while you're using the Makeswift Visual Builder
+will only be saved within the builder. Because of this, your site should behave
+as expected within Makeswift, without any action needed on your part.
+
+If you're still encountering issues, you can modify your browser settings:
+
+1. Go to **Preferences** > **Privacy & Security**
+2. Under the **Cookies and Site Data** section, click **Manage Exceptions**
+3. In the dialog that appears, enter your site's domain name and click **Allow**.
+
+For more information on modifying Firefox's cookie permissions for you site, [see this
+article](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection).
+
+### Safari
+
+To disable Safari's third-party cookie restrictions:
+1. Go to **Settings** > **Privacy**
+2. Uncheck the box for **Website tracking: Prevent cross-site tracking**.
+
+Disabling this setting will allow all website to set third-party cookies, not
+just your site within Makeswift. If you have privacy concerns, feel free to turn
+on the protections again when you're done editing your site in Makeswift.
+
+## Developer Settings
+
+If none of the above settings worked, you may need your developer to modify how
+cookies are set. Some browsers require that your site uses certain values when
+setting a cookie so that it can be properly set in a third-party context. See
+[this article](/developer/guides/how-to/setting-cookies) for more details.


### PR DESCRIPTION
Introduce documentation for modifying cookies so that they can be set within the builder. Includes docs for product users (modifying browser settings) and developers (modifying cookie attributes).