### PR TITLE
0.23 Upgrade Guide Code Snippets

### DIFF
--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -40,6 +40,25 @@ return {
 };
 ```
 
+You'll then need to make sure you're consuming this data in your `_app.tsx` file and passing it to the `<ReactRuntimeProvider>`.
+
+```tsx {3,8,9}
+export default function App({
+  Component,
+  pageProps: { previewMode, locale, ...pageProps },
+}: AppProps) {
+  return (
+    <ReactRuntimeProvider
+      runtime={runtime}
+      previewMode={previewMode}
+      locale={locale}
+    >
+      <Component {...pageProps} />
+    </ReactRuntimeProvider>
+  );
+}
+```
+
 Check out our updated [App Router](/developer/app-router/installation) and [Pages Router](/developer/pages-router/installation) installation guides to learn how to provide these props in both setups.
 
 ## Deprecated items
@@ -59,7 +78,7 @@ We've added a new [Group](/developer/reference/controls/group) control which is 
 We've added a new [Font](/developer/reference/controls/font) control which let's you select a `fontFamily`, `fontStyle`, and `fontWeight`.
 The available values are sourced from our Google Fonts integration within Makeswift and from the variants you pass to `getFonts` in your [MakeswiftApiHandler](/developer/reference/makeswift-api-handler).
 
-## New Apis
+## New APIs
 
 ### Built-in elements
 

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -12,9 +12,33 @@ If you haven't upgraded to `0.22.0` please read the [upgrading guide](/developer
 
 To initialize an instance of the [MakeswiftApiHandler](/developer/reference/makeswift-api-handler), you must now pass an instance of the [ReactRuntime](/developer/reference/runtime/constructor). See [MakeswiftApiHandler](/developer/reference/makeswift-api-handler) for full details.
 
+```diff
+- const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY);
++ const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, { runtime });
+```
+
 ### New props for `ReactRuntimeProvider`
 
 In order to support the new [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) API (details [below](#built-in-elements)), which can be rendered multiple times on a Next.js page, we had to make some changes to the Makeswift provider. The [ReactRuntimeProvider](/developer/reference/components/react-runtime-provider) component now accepts two new props: `previewMode` and `locale`. `previewMode` is required in all cases, while `locale` is required if your site supports more than one locale.
+
+```diff
+- <ReactRuntimeProvider runtime={runtime}>
++ <ReactRuntimeProvider runtime={runtime} previewMode={previewMode} locale={locale}>
+```
+
+#### Pages Router
+
+If you're using the [Pages Router](https://nextjs.org/docs/pages), you'll need to update the `getStaticProps` function in your optional catch-all route to include `previewMode` in its returned data.
+
+```diff
+return {
+  props: {
+    snapshot,
++   previewMode: Makeswift.getPreviewMode(previewData),
+    locale,
+  },
+};
+```
 
 Check out our updated [App Router](/developer/app-router/installation) and [Pages Router](/developer/pages-router/installation) installation guides to learn how to provide these props in both setups.
 
@@ -46,3 +70,7 @@ A good example of this would be a `<Header>` component that you want to be inclu
 To support this, we've included to new components, [`<MakeswiftComponent>`](/developer/reference/components/makeswift-component) and [`<Slot>`](/developer/reference/components/slot), along with a corresponding Makeswift client method, [`getComponentSnapshot`](/developer/reference/client/get-component-snapshot).
 
 Check out our new [editable-regions example](https://github.com/makeswift/makeswift/tree/main/examples/editable-regions) to learn how to combine these APIs to create a set of dynamic pages with a visually editable header, footer, and a slot for the main content.
+
+```
+
+```

--- a/developer/upgrading/0.23.0.mdx
+++ b/developer/upgrading/0.23.0.mdx
@@ -28,7 +28,7 @@ In order to support the new [`<MakeswiftComponent>`](/developer/reference/compon
 
 #### Pages Router
 
-If you're using the [Pages Router](https://nextjs.org/docs/pages), you'll need to update the `getStaticProps` function in your optional catch-all route to include `previewMode` in its returned data.
+If you're using the [Pages Router](https://nextjs.org/docs/pages), you'll need to update the `getStaticProps` function in your optional catch-all route to include `previewMode` in its returned data so that it becomes available in the `_app.tsx` file.
 
 ```diff
 return {
@@ -40,7 +40,7 @@ return {
 };
 ```
 
-You'll then need to make sure you're consuming this data in your `_app.tsx` file and passing it to the `<ReactRuntimeProvider>`.
+Then, you can consume this data in your `_app.tsx` file and pass it to the `<ReactRuntimeProvider>`.
 
 ```tsx {3,8,9}
 export default function App({

--- a/mint.json
+++ b/mint.json
@@ -152,7 +152,7 @@
           ]
         },
         {
-          "group": "How to",
+          "group": "How To",
           "pages": ["developer/guides/how-to/built-in-components"]
         },
         "developer/guides/troubleshooting",


### PR DESCRIPTION
- add diffs for snippet examples
- add callout for pages router that requires `previewData` to be returned from `getStaticProps`