### PR TITLE
fix: update snapshot methods to include allowLocaleFallback

### DIFF
--- a/developer/reference/client/get-component-snapshot.mdx
+++ b/developer/reference/client/get-component-snapshot.mdx
@@ -23,6 +23,9 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
        <ParamField query="locale" type="string">
          A valid locale string.
        </ParamField>
+       <ParamField query="allowLocaleFallback" type="boolean" default={true}>
+         Controls whether a request for a localized component should fallback to the default locale if the requested locale is not available.
+       </ParamField>
      </Expandable>
    </ParamField>
 
@@ -77,3 +80,9 @@ const snapshot = await client.getComponentSnapshot(id, {
   locale,
 });
 ```
+
+## Changelog
+
+| Version                                                                                          | Changes                               |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| [`v0.23.0`](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.23.0) | `getComponentSnapshot` method introduced |

--- a/developer/reference/client/get-page-snapshot.mdx
+++ b/developer/reference/client/get-page-snapshot.mdx
@@ -23,6 +23,9 @@ import PagesCatchAllLocalizedExample from "/snippets/pages-router/catch-all-loca
         <ParamField query="locale" type="string">
           A valid locale string (ex. `"en-US"`).
         </ParamField>
+        <ParamField query="allowLocaleFallback" type="boolean" default={true}>
+          Controls whether a request for a localized page should fallback to the default locale if the requested locale is not available.
+       </ParamField>
       </Expandable>
     </ParamField>
 
@@ -46,3 +49,11 @@ The following example sets up a [catch all route](https://nextjs.org/docs/pages/
 The following example uses the `locale` param in `getStaticProps` to fetch a localized snapshot of a page.
 
 <PagesCatchAllLocalizedExample />
+
+## Changelog
+
+| Version                                                                                          | Changes                               |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| [`v0.24.0`](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.24.0) | Adds `allowLocaleFallback` option |
+| [`v0.11.0`](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.11.0) | Adds `locale` option |
+| [`v0.2.0`](https://github.com/makeswift/makeswift/releases/tag/%40makeswift%2Fruntime%400.2.0) | `getPageSnapshot` method introduced |


### PR DESCRIPTION
Update client `getSnapshot` methods to include docs for the `allowLocaleFallback` param. Also adds changelogs to both methods.