### PR TITLE
refactor: make Developer/Troubleshooting a group

### DIFF
--- a/developer/guides/troubleshooting/builder-is-not-loading.mdx
+++ b/developer/guides/troubleshooting/builder-is-not-loading.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting
+title: Builder isn't loading
 ---
 
 ## Builder isn't loading in Safari

--- a/mint.json
+++ b/mint.json
@@ -165,7 +165,10 @@
             "developer/guides/how-to/setting-cookies"
           ]
         },
-        "developer/guides/troubleshooting",
+        {
+          "group": "Troubleshooting",
+          "pages": ["developer/guides/troubleshooting/builder-is-not-loading"]
+        },
         "developer/guides/environments",
         {
           "group": "Upgrading",


### PR DESCRIPTION
## Summary

I am planning to put more content under `Developer`/`Troubleshooting` and wanted it to be a group rather than a page.

### Before

![CleanShot 2025-04-22 at 15 51 52@2x](https://github.com/user-attachments/assets/0ff24645-c07b-448d-9b26-605a7c4832bb)

### After

![CleanShot 2025-04-22 at 15 52 17@2x](https://github.com/user-attachments/assets/9c2edf9e-4c30-4fab-b972-b07f2ddaa2b6)
