### PR TITLE
Mark getSitemap was removed

### DIFF
--- a/developer/reference/client/get-sitemap.mdx
+++ b/developer/reference/client/get-sitemap.mdx
@@ -3,10 +3,13 @@ title: "getSitemap"
 description: "An instance method that provides SEO information about the pages created within Makeswift. You can combine the results of `getSitemap` with SEO information for your hardcoded pages to create a sitemap."
 ---
 
-<Warning> 
-  This method has been **deprecated** and will be removed in a future 
-  runtime release. Use the [`getPages`](/developer/reference/client/get-pages) method to create a sitemap instead,
-  [see the documentation here](/developer/reference/client/get-pages#generating-a-sitemap).
+<Warning>
+  This method was **deprecated** in [v0.19.0](/developer/upgrading/0.19.0) and
+  was removed in
+  [v0.25.0](/developer/upgrading/0.25.0#removed-deprecated-client-getsitemap-method).
+  Use the [`getPages`](/developer/reference/client/get-pages) method to create a
+  sitemap instead, [see the documentation
+  here](/developer/reference/client/get-pages#generating-a-sitemap).
 </Warning>
 
 <Note>
@@ -38,9 +41,9 @@ description: "An instance method that provides SEO information about the pages c
 
 ```ts
 type Sitemap = {
-  id: string
-  loc: string
-  lastmod?: string
+  id: string;
+  loc: string;
+  lastmod?: string;
   changefreq?:
     | "always"
     | "hourly"
@@ -48,13 +51,13 @@ type Sitemap = {
     | "weekly"
     | "monthly"
     | "yearly"
-    | "never"
-  priority?: number
+    | "never";
+  priority?: number;
   alternateRefs?: {
-    hreflang: string
-    href: string
-  }[]
-}[]
+    hreflang: string;
+    href: string;
+  }[];
+}[];
 ```
 
 ## Examples
@@ -64,18 +67,18 @@ type Sitemap = {
 The following example uses `getSitemap` with `next-sitemap`, a popular Next.js library for generating sitemaps.
 
 ```ts pages/sitemap.xml.ts
-import { Makeswift } from "@makeswift/runtime/next"
+import { Makeswift } from "@makeswift/runtime/next";
 // Use `getServerSideSitemapLegacy` for sitemap entries in the pages directory.
-import { getServerSideSitemapLegacy } from "next-sitemap"
+import { getServerSideSitemapLegacy } from "next-sitemap";
 
-import { client } from "makeswift/client"
-import { runtime } from "makeswift/runtime"
-import "makeswift/components"
+import { client } from "makeswift/client";
+import { runtime } from "makeswift/runtime";
+import "makeswift/components";
 
 export async function getServerSideProps(context) {
-  const sitemap = await client.getSitemap()
+  const sitemap = await client.getSitemap();
 
-  return getServerSideSitemapLegacy(context, sitemap)
+  return getServerSideSitemapLegacy(context, sitemap);
 }
 
 export default function Sitemap() {}
@@ -86,17 +89,17 @@ export default function Sitemap() {}
 The following example uses the `pathnamePrefix` option to filter results to only include pages with a pathname beginning with `/blog/`.
 
 ```ts pages/sitemap.xml.ts
-import { Makeswift } from "@makeswift/runtime/next"
-import { getServerSideSitemapLegacy } from "next-sitemap"
+import { Makeswift } from "@makeswift/runtime/next";
+import { getServerSideSitemapLegacy } from "next-sitemap";
 
-import { client } from "makeswift/client"
-import { runtime } from "makeswift/runtime"
-import "makeswift/components"
+import { client } from "makeswift/client";
+import { runtime } from "makeswift/runtime";
+import "makeswift/components";
 
 export async function getServerSideProps(context) {
-  const blogSitemap = await client.getSitemap({ pathnamePrefix: "/blog/" })
+  const blogSitemap = await client.getSitemap({ pathnamePrefix: "/blog/" });
 
-  return getServerSideSitemapLegacy(context, blogSitemap)
+  return getServerSideSitemapLegacy(context, blogSitemap);
 }
 
 export default function BlogSitemap() {}
@@ -107,26 +110,26 @@ export default function BlogSitemap() {}
 The following example uses the `limit` and `after` field to paginate the results of `getSitemap` 10 entries at a time.
 
 ```ts pages/sitemap.xml.ts
-import { Makeswift, Sitemap } from "@makeswift/runtime/next"
-import { getServerSideSitemapLegacy } from "next-sitemap"
+import { Makeswift, Sitemap } from "@makeswift/runtime/next";
+import { getServerSideSitemapLegacy } from "next-sitemap";
 
-import { client } from "makeswift/client"
-import { runtime } from "makeswift/runtime"
-import "makeswift/components"
+import { client } from "makeswift/client";
+import { runtime } from "makeswift/runtime";
+import "makeswift/components";
 
 export async function getServerSideProps(context) {
-  const sitemap: Sitemap = []
-  let page: Sitemap = []
-  let after: string | undefined = undefined
+  const sitemap: Sitemap = [];
+  let page: Sitemap = [];
+  let after: string | undefined = undefined;
 
   do {
-    page = await client.getSitemap({ limit: 10, after })
+    page = await client.getSitemap({ limit: 10, after });
 
-    sitemap.push(...page)
-    after = page.at(-1)?.id
-  } while (page.length > 0)
+    sitemap.push(...page);
+    after = page.at(-1)?.id;
+  } while (page.length > 0);
 
-  return getServerSideSitemapLegacy(context, sitemap)
+  return getServerSideSitemapLegacy(context, sitemap);
 }
 
 export default function Sitemap() {}
@@ -137,17 +140,17 @@ export default function Sitemap() {}
 The following example uses the `locale` option to fetch the sitemap for a specific locale.
 
 ```ts pages/sitemap.xml.ts
-import { Makeswift } from "@makeswift/runtime/next"
-import { getServerSideSitemapLegacy } from "next-sitemap"
+import { Makeswift } from "@makeswift/runtime/next";
+import { getServerSideSitemapLegacy } from "next-sitemap";
 
-import { client } from "makeswift/client"
-import { runtime } from "makeswift/runtime"
-import "makeswift/components"
+import { client } from "makeswift/client";
+import { runtime } from "makeswift/runtime";
+import "makeswift/components";
 
 export async function getServerSideProps(context) {
-  const sitemap = await client.getSitemap({ locale: "es" })
+  const sitemap = await client.getSitemap({ locale: "es" });
 
-  return getServerSideSitemapLegacy(context, sitemap)
+  return getServerSideSitemapLegacy(context, sitemap);
 }
 
 export default function Sitemap() {}


### PR DESCRIPTION
`getSitemap` has officially been removed. Updated the callout to clarify that.