### PR TITLE
Fix typo in adding fonts guide

### DIFF
--- a/developer/guides/how-to/add-custom-fonts.mdx
+++ b/developer/guides/how-to/add-custom-fonts.mdx
@@ -6,7 +6,7 @@ description: Add fonts to your Makeswift & Next.js project.
 import AppCustomNextFontExample from "/snippets/app-router/custom-next-font.mdx";
 import PagesCustomNextFontExample from "/snippets/pages-router/custom-next-font.mdx";
 
-You can use any web font with Makeswift not just Google Fonts. Fonts can come from your brand's type license, a foundry, or any other source, as long as you can serve them as standard web font files (e.g., .woff2, .woff, .tff).
+You can use any web font with Makeswift not just Google Fonts. Fonts can come from your brand's type license, a foundry, or any other source, as long as you can serve them as standard web font files (e.g., .woff2, .woff, .ttf).
 Makeswift exposes those fonts in the builder once you register them in the [API handler](/developer/reference/makeswift-api-handler).
 
 Adding fonts to Makeswift involves two steps:


### PR DESCRIPTION
There was a typo in the adding fonts guide where it referenced a `.tff` file when it should have said `.ttf`