### PR TITLE
DEVDOCS-6502 - Replace 'tooltip' with 'popover'

### DIFF
--- a/developer/reference/components/makeswift-component.mdx
+++ b/developer/reference/components/makeswift-component.mdx
@@ -245,7 +245,7 @@ Click this [link](https://docs.makeswift.com/product/introduction) to learn more
 ...
 
 ```
-You should now be able to see an info icon next to the label when selecting the component in the Visual Builder. To view your description, simply hover over the label and the tooltip will open.
+You should now be able to see an info icon next to the label when selecting the component in the Visual Builder. To view your description, simply hover over the label and the popover will open.
 
 <Frame>
   <img


### PR DESCRIPTION
Replaced the word 'tooltip' with 'popover' to accurately reflect what is shown to the user.