### PR TITLE
DEVDOCS-6522 - Fix controls description

### DIFF
--- a/developer/concepts.mdx
+++ b/developer/concepts.mdx
@@ -19,7 +19,7 @@ You can read more about props in the [React documentation](https://react.dev/lea
 
 ## Controls
 
-Controls describe the way users can pass data to your components props. Each control maps a [prop](#props) on your component to user interface elements such as <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip>. Controls are defined when [registering components](/developer/reference/runtime/register-component).
+Controls describe the way users can pass data to your components' props. Each control maps a [prop](#props) on your component to user interface elements such as <Tooltip tip="Form elements in the right sidebar of the Makeswift builder">panels</Tooltip> and <Tooltip tip="Interactive elements placed on the Makeswift builder preview">overlays</Tooltip>. Controls are defined when [registering components](/developer/reference/runtime/register-component).
 
 There are two types of controls: [basic](#basic-controls) and [composable](#composable-controls) controls.
 


### PR DESCRIPTION
The current sentence is: 'Controls describe the way users can pass data to your components props.' 

It's been updated to: 'Controls describe the way users can pass data to your components' props.'