### PR TITLE
fix: rename Public API -> REST API

### DIFF
--- a/developer/reference/api/authentication.mdx
+++ b/developer/reference/api/authentication.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Authentication"
-description: "Create an app and get your API key to authenticate with the Makeswift Public API."
+description: "Create an app and get your API key to authenticate with the Makeswift REST API."
 ---
 
 import ReadinessBadge from "/snippets/readinessBadge.jsx";
 
 <ReadinessBadge type="beta" />
 
-To use the Makeswift Public API, you'll need to create an app and obtain an API key. This guide walks you through the setup process.
+To use the Makeswift REST API, you'll need to create an app and obtain an API key. This guide walks you through the setup process.
 
 ## Prerequisites
 

--- a/developer/reference/api/overview.mdx
+++ b/developer/reference/api/overview.mdx
@@ -7,7 +7,7 @@ import ReadinessBadge from "/snippets/readinessBadge.jsx";
 
 <ReadinessBadge type="beta" />
 
-The Makeswift Public API allows you to programmatically manage your Makeswift resources. Use it to automate workflows, integrate with external systems, or build custom tooling.
+The Makeswift REST API allows you to programmatically manage your Makeswift resources. Use it to automate workflows, integrate with external systems, or build custom tooling.
 
 ## Base URL
 

--- a/docs.json
+++ b/docs.json
@@ -278,7 +278,7 @@
                 ]
               },
               {
-                "group": "Public API",
+                "group": "REST API",
                 "tag": "beta",
                 "pages": [
                   "developer/reference/api/overview",


### PR DESCRIPTION
## Summary

We decided to rename "Public API" to be "REST API".

| Before | After |
|--------|--------|
|  <img width="200" alt="CleanShot 2026-01-12 at 10 03 41@2x" src="https://github.com/user-attachments/assets/cfe72eba-6916-4804-b80b-3d8011bb2234" /> | <img width="200" alt="CleanShot 2026-01-12 at 10 03 51@2x" src="https://github.com/user-attachments/assets/47738c06-8ee8-44f5-b04d-1de4b0adaa81" /> |
| <img width="400" alt="CleanShot 2026-01-12 at 09 19 36@2x" src="https://github.com/user-attachments/assets/86c925cf-fe3a-45f5-a149-2139993707cb" /> | <img width="400" alt="CleanShot 2026-01-12 at 09 19 46@2x" src="https://github.com/user-attachments/assets/db397ad3-de44-4377-b24c-9b12e444fdc9" /> |
| <img width="400" alt="CleanShot 2026-01-12 at 09 20 35@2x" src="https://github.com/user-attachments/assets/cb50293b-ccfd-46d2-a79c-0c1a85440ebf" /> | <img width="400" alt="CleanShot 2026-01-12 at 09 20 46@2x" src="https://github.com/user-attachments/assets/244d898d-e893-449a-b1d9-c0a332a16ea6" /> |


