### PR TITLE
add docs for rate limiting 

### DIFF
--- a/developer/reference/api/authentication.mdx
+++ b/developer/reference/api/authentication.mdx
@@ -9,6 +9,10 @@ import ReadinessBadge from "/snippets/readinessBadge.jsx";
 
 To use the Makeswift REST API, you'll need to create an app and obtain an API key. This guide walks you through the setup process.
 
+<Note>
+  While both API Key and Bearer Token authentication methods are supported, you must use **only one** authentication method per request. Requests that include both an API Key and Bearer Token will be rejected.
+</Note>
+
 ## Prerequisites
 
 Apps is currently an early access feature. You'll need to enable it before you can create an app.

--- a/developer/reference/api/overview.mdx
+++ b/developer/reference/api/overview.mdx
@@ -66,9 +66,9 @@ List endpoints return paginated results:
 
 List endpoints support cursor-based pagination using the following query parameters:
 
-| Parameter        | Type   | Default | Description                                              |
-| ---------------- | ------ | ------- | -------------------------------------------------------- |
-| `limit`          | number | `20`    | Number of results to return (max `100`)                  |
+| Parameter       | Type   | Default | Description                                              |
+| --------------- | ------ | ------- | -------------------------------------------------------- |
+| `limit`         | number | `20`    | Number of results to return (max `100`)                  |
 | `startingAfter` | string | -       | Cursor for fetching results after a specific resource ID |
 
 To paginate through results:
@@ -87,6 +87,10 @@ curl "https://api.makeswift.com/v2/sites/YOUR_SITE_ID/pages?limit=10&startingAft
   -H "x-api-key: your-api-key"
 ```
 
+## Rate Limits
+
+The API implements rate limiting per authentication credential (API key or Bearer token) to ensure fair usage and protect service stability. Rate limits may be adjusted over time.
+
 ## Errors
 
 The API uses standard HTTP status codes and returns consistent error responses:
@@ -100,6 +104,7 @@ The API uses standard HTTP status codes and returns consistent error responses:
 | `403`  | Forbidden - insufficient permissions      |
 | `404`  | Not found                                 |
 | `409`  | Conflict - resource already exists        |
+| `429`  | Too many requests - rate limit exceeded   |
 
 ### 400 Bad Request
 
@@ -164,5 +169,17 @@ Returned when attempting to create a resource that already exists.
   "object": "error",
   "code": "conflict",
   "message": "A page with this path already exists"
+}
+```
+
+### 429 Too Many Requests
+
+Returned when the rate limit is exceeded.
+
+```json
+{
+  "object": "error",
+  "code": "too_many_requests",
+  "message": "Rate limit exceeded"
 }
 ```


### PR DESCRIPTION
This PR adds information about the Rate Limit.
it adds a section below Pagination in: Developer -> Rest API -> Overview.
<img width="1315" height="843" alt="Captura de pantalla 2026-02-16 a la(s) 11 01 56 a m" src="https://github.com/user-attachments/assets/8fd6b8f0-5db8-40f4-a236-4269d06525ce" />


It also adds the error message

<img width="1412" height="787" alt="Captura de pantalla 2026-02-16 a la(s) 11 02 23 a m" src="https://github.com/user-attachments/assets/53199ae0-5217-488f-a049-b55957a1759a" />

Alex's comments was right. I have followed his instruction on this pr
